### PR TITLE
Image history

### DIFF
--- a/app/api/engagement-image/route.ts
+++ b/app/api/engagement-image/route.ts
@@ -41,18 +41,14 @@ Text style: ${textModes}
 Title: ${item.title}
 Student-facing text:
 ${item.body}
-${visualBrief ? `Visual brief: ${visualBrief}` : "Visual brief: Show the main scene, concept, or conversation implied by the text."}
+${visualBrief ? `Visual brief: ${visualBrief}` : "Visual brief: Show the main scene, phenomenon, or conversation implied by the text."}
 
 If the material includes dialogue, clearly show the speakers and what they are reacting to.
 If the material includes questions, show the scene students should reason about.
-If the material describes a concept or process, make it visually central.
+If the material describes a phenomenon, make that phenomenon visually central.
 Style: clean, minimal, classroom-friendly.
-When it helps understanding, add concise annotations directly on the image:
-- Use simple arrows to indicate relationships, sequences, or key connections between elements.
-- Add short text labels (1-4 words max) next to key objects or arrows to name important concepts or elements.
-- Keep labels in plain sans-serif font, high contrast against the background.
-- Do not add paragraphs, sentences, captions, watermarks, or decorative text. Only functional labels and arrows.
-If the scene is self-explanatory without annotations, omit them.`;
+Hard requirement: the image must contain zero text of any kind.
+Do not render words, letters, numbers, equations, symbols, speech bubbles with text, captions, labels, posters, signs, UI text, or watermarks.`;
 };
 
 const MAX_REFINEMENT_PROMPT_LENGTH = 500;

--- a/app/api/engagement-image/route.ts
+++ b/app/api/engagement-image/route.ts
@@ -47,8 +47,12 @@ If the material includes dialogue, clearly show the speakers and what they are r
 If the material includes questions, show the scene students should reason about.
 If the material describes a phenomenon, make that phenomenon visually central.
 Style: clean, minimal, classroom-friendly.
-Hard requirement: the image must contain zero text of any kind.
-Do not render words, letters, numbers, equations, symbols, speech bubbles with text, captions, labels, posters, signs, UI text, or watermarks.`;
+When it helps understanding, add concise annotations directly on the image:
+- Use simple arrows to indicate direction of motion, forces, cause-and-effect, or relationships between objects.
+- Add short text labels (1-4 words max) next to key objects or arrows to name forces, objects, or concepts (e.g. "gravity", "friction", "push", "before", "after").
+- Keep labels in plain sans-serif font, high contrast against the background.
+- Do not add paragraphs, sentences, captions, watermarks, or decorative text. Only functional labels and arrows.
+If the scene is self-explanatory without annotations, omit them.`;
 };
 
 const MAX_REFINEMENT_PROMPT_LENGTH = 500;
@@ -125,7 +129,7 @@ export async function POST(request: Request) {
         model,
         prompt,
         size: "1024x1024",
-        quality: "low",
+        quality: "high",
         output_format: "webp",
       });
     }

--- a/app/api/engagement-image/route.ts
+++ b/app/api/engagement-image/route.ts
@@ -1,4 +1,4 @@
-import OpenAI from "openai";
+import OpenAI, { toFile } from "openai";
 import { NextResponse } from "next/server";
 import { getMedia, upsertMedia } from "@/lib/nosql";
 
@@ -51,6 +51,28 @@ Hard requirement: the image must contain zero text of any kind.
 Do not render words, letters, numbers, equations, symbols, speech bubbles with text, captions, labels, posters, signs, UI text, or watermarks.`;
 };
 
+const MAX_REFINEMENT_PROMPT_LENGTH = 500;
+
+const isSafetyRejection = (error: unknown): boolean => {
+  if (!(error instanceof Error)) return false;
+  const msg = error.message.toLowerCase();
+  return msg.includes("safety") || msg.includes("content_policy") || msg.includes("policy") || msg.includes("moderation");
+};
+
+const prepareImageInput = async (
+  client: OpenAI,
+  imageUrl: string,
+) => {
+  if (imageUrl.startsWith("data:")) {
+    const base64Part = imageUrl.split(",")[1];
+    const buffer = Buffer.from(base64Part, "base64");
+    return toFile(buffer, "image.webp", { type: "image/webp" });
+  }
+  const imgRes = await fetch(imageUrl);
+  const imgBuffer = Buffer.from(await imgRes.arrayBuffer());
+  return toFile(imgBuffer, "image.webp", { type: "image/webp" });
+};
+
 export const maxDuration = 60; // seconds – image generation can take 15-30s
 
 export async function POST(request: Request) {
@@ -70,6 +92,8 @@ export async function POST(request: Request) {
       classId,
       assignmentId,
       studentId,
+      refinementPrompt,
+      previousImageUrl,
     } = (await request.json()) as {
       item: ContentItem;
       plan: Plan | null;
@@ -77,19 +101,34 @@ export async function POST(request: Request) {
       classId?: string;
       assignmentId?: string;
       studentId?: string;
+      refinementPrompt?: string;
+      previousImageUrl?: string;
     };
 
     const model = process.env.OPENAI_IMAGE_MODEL ?? "gpt-image-1";
-    const prompt = buildPrompt(item, plan, answers);
+    const trimmedRefine = refinementPrompt?.trim().slice(0, MAX_REFINEMENT_PROMPT_LENGTH);
+    const isRefine = !!(trimmedRefine && previousImageUrl);
 
-    // webp + low quality = fast generation + small payload (avoids Amplify 30s timeout)
-    const result = await client.images.generate({
-      model,
-      prompt,
-      size: "1024x1024",
-      quality: "low",
-      output_format: "webp",
-    });
+    let result;
+    if (isRefine) {
+      const imageInput = await prepareImageInput(client, previousImageUrl);
+      result = await client.images.edit({
+        model,
+        image: imageInput,
+        prompt: trimmedRefine,
+        size: "1024x1024",
+      });
+    } else {
+      // Normal generation from scratch
+      const prompt = buildPrompt(item, plan, answers);
+      result = await client.images.generate({
+        model,
+        prompt,
+        size: "1024x1024",
+        quality: "low",
+        output_format: "webp",
+      });
+    }
 
     const data = result.data?.[0];
     const base64 = data?.b64_json;
@@ -133,7 +172,12 @@ export async function POST(request: Request) {
   } catch (error) {
     const message =
       error instanceof Error ? error.message : "Failed to generate image.";
+    const isSafety = isSafetyRejection(error);
     console.error("engagement-image error:", message);
-    return NextResponse.json({ error: message }, { status: 500 });
+    return NextResponse.json({
+      error: isSafety
+        ? "Your refinement instruction was flagged by content policy. Please rephrase and try again."
+        : message,
+    }, { status: isSafety ? 422 : 500 });
   }
 }

--- a/app/api/engagement-image/route.ts
+++ b/app/api/engagement-image/route.ts
@@ -117,6 +117,8 @@ export async function POST(request: Request) {
         image: imageInput,
         prompt: trimmedRefine,
         size: "1024x1024",
+        quality: "high",
+        output_format: "webp",
       });
     } else {
       // Normal generation from scratch

--- a/app/api/engagement-image/route.ts
+++ b/app/api/engagement-image/route.ts
@@ -33,7 +33,7 @@ const buildPrompt = (
   const textModes = item.textModes?.length ? item.textModes.join(", ") : item.type;
   const visualBrief = item.visualBrief?.trim();
 
-  return `Create a simple, student-friendly illustration for an ${gradeLevel} physics lesson.
+  return `Create a simple, student-friendly illustration for a ${gradeLevel} lesson.
 This image will be shown directly to students next to the material below.
 Topic: ${topic}
 Strategy inspiration: ${planName}
@@ -41,15 +41,15 @@ Text style: ${textModes}
 Title: ${item.title}
 Student-facing text:
 ${item.body}
-${visualBrief ? `Visual brief: ${visualBrief}` : "Visual brief: Show the main scene, phenomenon, or conversation implied by the text."}
+${visualBrief ? `Visual brief: ${visualBrief}` : "Visual brief: Show the main scene, concept, or conversation implied by the text."}
 
 If the material includes dialogue, clearly show the speakers and what they are reacting to.
 If the material includes questions, show the scene students should reason about.
-If the material describes a phenomenon, make that phenomenon visually central.
+If the material describes a concept or process, make it visually central.
 Style: clean, minimal, classroom-friendly.
 When it helps understanding, add concise annotations directly on the image:
-- Use simple arrows to indicate direction of motion, forces, cause-and-effect, or relationships between objects.
-- Add short text labels (1-4 words max) next to key objects or arrows to name forces, objects, or concepts (e.g. "gravity", "friction", "push", "before", "after").
+- Use simple arrows to indicate relationships, sequences, or key connections between elements.
+- Add short text labels (1-4 words max) next to key objects or arrows to name important concepts or elements.
 - Keep labels in plain sans-serif font, high contrast against the background.
 - Do not add paragraphs, sentences, captions, watermarks, or decorative text. Only functional labels and arrows.
 If the scene is self-explanatory without annotations, omit them.`;

--- a/app/api/media/route.ts
+++ b/app/api/media/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getMedia, listMedia } from "@/lib/nosql";
+import { getMedia, listMedia, upsertMedia } from "@/lib/nosql";
 
 /**
  * GET /api/media
@@ -63,6 +63,50 @@ export async function GET(request: NextRequest) {
     const message =
       error instanceof Error ? error.message : "Failed to retrieve media.";
     console.error("media route error:", message);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+/**
+ * PUT /api/media
+ *
+ * Persist or update a media record (e.g. when the teacher selects a
+ * different image version to be the "active" one for gallery/video).
+ */
+export async function PUT(request: NextRequest) {
+  try {
+    const { classId, assignmentId, studentId, contentItemId, mediaType, mimeType, dataUrl } =
+      (await request.json()) as {
+        classId?: string;
+        assignmentId?: string;
+        studentId?: string;
+        contentItemId?: string;
+        mediaType?: "image" | "video";
+        mimeType?: string;
+        dataUrl?: string;
+      };
+
+    if (!classId || !assignmentId || !studentId || !contentItemId || !mediaType || !dataUrl) {
+      return NextResponse.json(
+        { error: "classId, assignmentId, studentId, contentItemId, mediaType, and dataUrl are required." },
+        { status: 400 },
+      );
+    }
+
+    await upsertMedia({
+      classId,
+      assignmentId,
+      studentId,
+      contentItemId,
+      mediaType,
+      mimeType: mimeType ?? "image/webp",
+      dataUrl,
+    });
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to persist media.";
+    console.error("media PUT error:", message);
     return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/app/components/AuthContext.tsx
+++ b/app/components/AuthContext.tsx
@@ -139,61 +139,64 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   });
 
   useEffect(() => {
-    const authenticateToken = (token: string) => {
-      fetch("/api/auth/verify", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ token }),
-      })
-        .then(async (res) => {
+    const run = async () => {
+      const authenticateToken = async (token: string) => {
+        try {
+          const res = await fetch("/api/auth/verify", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ token }),
+          });
           if (!res.ok) {
             const body = await res.json().catch(() => ({}));
             throw new Error(
               (body as Record<string, string>).error ?? "Authentication failed.",
             );
           }
-          return res.json();
-        })
-        .then((data) => {
+          const data = await res.json();
           storeSSOToken(token);
           clearStoredMockUser();
           setState({ user: data.user as UserContext, loading: false, error: null });
-        })
-        .catch((err) => {
+        } catch (err) {
           clearStoredSSOToken();
           setState({
             user: null,
             loading: false,
             error: err instanceof Error ? err.message : "Authentication failed.",
           });
-        });
+        }
+      };
+
+      const urlToken = parseSSOFromUrl();
+      if (urlToken) {
+        await authenticateToken(urlToken);
+        return;
+      }
+
+      const mockUserFromUrl = parseMockUserFromUrl();
+      if (mockUserFromUrl) {
+        await Promise.resolve();
+        setState({ user: mockUserFromUrl, loading: false, error: null });
+        return;
+      }
+
+      const storedToken = readStoredSSOToken();
+      if (storedToken) {
+        await authenticateToken(storedToken);
+        return;
+      }
+
+      const storedMockUser = readStoredMockUser();
+      if (storedMockUser) {
+        await Promise.resolve();
+        setState({ user: storedMockUser, loading: false, error: null });
+        return;
+      }
+
+      await Promise.resolve();
+      setState({ user: null, loading: false, error: "No SSO token provided." });
     };
-
-    const urlToken = parseSSOFromUrl();
-    if (urlToken) {
-      authenticateToken(urlToken);
-      return;
-    }
-
-    const mockUserFromUrl = parseMockUserFromUrl();
-    if (mockUserFromUrl) {
-      setState({ user: mockUserFromUrl, loading: false, error: null });
-      return;
-    }
-
-    const storedToken = readStoredSSOToken();
-    if (storedToken) {
-      authenticateToken(storedToken);
-      return;
-    }
-
-    const storedMockUser = readStoredMockUser();
-    if (storedMockUser) {
-      setState({ user: storedMockUser, loading: false, error: null });
-      return;
-    }
-
-    setState({ user: null, loading: false, error: "No SSO token provided." });
+    run();
   }, []);
 
   return <AuthCtx.Provider value={state}>{children}</AuthCtx.Provider>;

--- a/app/components/TeacherView.tsx
+++ b/app/components/TeacherView.tsx
@@ -12,6 +12,7 @@ import type {
   Plan,
   ContentItem,
   ImageState,
+  ImageVersion,
   VideoState,
   StudentStrategyResult,
   Lesson,
@@ -19,6 +20,8 @@ import type {
   StudentAnswer,
   TextMode,
 } from "@/lib/types";
+
+const MAX_IMAGE_VERSIONS = 10;
 
 type Props = {
   user: UserContext;
@@ -43,6 +46,10 @@ type PersistedDraft = {
 };
 
 
+// Module-level cache: survives component unmount/remount during SPA navigation (Link).
+// Lost only on full page refresh — acceptable trade-off vs. localStorage size limits.
+const imageHistoryCache = new Map<string, { history: ImageVersion[]; historyIndex: number }>();
+
 const LEGACY_DRAFT_STORAGE_KEY = "engage-agent:draft:v2";
 const DRAFT_STORAGE_PREFIX = "engage-agent:draft:v3";
 const DRAFT_VERSION = 2;
@@ -65,7 +72,12 @@ const trimPersistedImageState = (state: ImageState): ImageState | null => {
   }
 
   if (state.status === "ready" && state.url && !state.url.startsWith("data:")) {
-    return { status: "ready", url: state.url };
+    const trimmedHistory = state.history?.filter((v) => !v.url.startsWith("data:"));
+    return {
+      status: "ready",
+      url: state.url,
+      ...(trimmedHistory?.length ? { history: trimmedHistory, historyIndex: Math.min(state.historyIndex ?? 0, trimmedHistory.length - 1) } : {}),
+    };
   }
 
   return null;
@@ -497,7 +509,14 @@ export default function TeacherView({ user }: Props) {
                   state.status === "error" ||
                   (state.status === "ready" && Boolean(state.url))
                 ),
-            ),
+            ).map(([itemId, state]) => {
+              // Merge cached history back (survives SPA navigation even when base64 was trimmed)
+              const cached = imageHistoryCache.get(itemId);
+              if (cached && state.status === "ready") {
+                return [itemId, { ...state, history: cached.history, historyIndex: cached.historyIndex, url: cached.history[cached.historyIndex]?.url ?? state.url }];
+              }
+              return [itemId, state];
+            }),
           ) as Record<string, ImageState>;
           const restoredVideos = Object.fromEntries(
             Object.entries(draft.videos ?? {}).filter(
@@ -519,7 +538,20 @@ export default function TeacherView({ user }: Props) {
           setAnnotationReason(draft.annotationReason ?? "");
           setAnnotationStatus(draft.annotationStatus ?? "idle");
           setContent(restoredContent);
-          setImages(restoredImages);
+          // Restore images from cache for items that were stripped from localStorage
+          const mergedImages = { ...restoredImages };
+          for (const item of restoredContent) {
+            if (!mergedImages[item.id] && imageHistoryCache.has(item.id)) {
+              const cached = imageHistoryCache.get(item.id)!;
+              mergedImages[item.id] = {
+                status: "ready",
+                url: cached.history[cached.historyIndex]?.url,
+                history: cached.history,
+                historyIndex: cached.historyIndex,
+              };
+            }
+          }
+          setImages(mergedImages);
           setVideos(restoredVideos);
           setSelectedForPublish(new Set((draft.selectedForPublish ?? []).filter((itemId) => contentIds.has(itemId))));
           setPublishedContentIds(new Set((draft.publishedContentIds ?? []).filter((itemId) => contentIds.has(itemId))));
@@ -555,6 +587,15 @@ export default function TeacherView({ user }: Props) {
     if (!hasPendingVideos) return;
     persistDraftSnapshot(buildDraftSnapshot());
   }, [isHydrated, videos, buildDraftSnapshot, persistDraftSnapshot]);
+
+  // Sync image history to module-level cache so it survives SPA navigation
+  useEffect(() => {
+    for (const [itemId, state] of Object.entries(images)) {
+      if (state.history?.length) {
+        imageHistoryCache.set(itemId, { history: state.history, historyIndex: state.historyIndex ?? 0 });
+      }
+    }
+  }, [images]);
 
   // Restore persisted Step 3 media/publish state before any regeneration kicks in.
   useEffect(() => {
@@ -595,7 +636,26 @@ export default function TeacherView({ user }: Props) {
             }
           }
 
-          setImages((prev) => ({ ...prev, ...persistedImages }));
+          setImages((prev) => {
+            const merged = { ...prev };
+            for (const [itemId, persisted] of Object.entries(persistedImages)) {
+              const existing = merged[itemId];
+              if (existing?.history?.length) {
+                // Preserve in-memory history
+                merged[itemId] = { ...persisted, history: existing.history, historyIndex: existing.historyIndex };
+              } else if (persisted.url) {
+                // Initialize history for DB-restored images
+                merged[itemId] = {
+                  ...persisted,
+                  history: [{ url: persisted.url, createdAt: new Date().toISOString() }],
+                  historyIndex: 0,
+                };
+              } else {
+                merged[itemId] = persisted;
+              }
+            }
+            return merged;
+          });
           setVideos((prev) => ({ ...prev, ...persistedVideos }));
         }
 
@@ -715,7 +775,19 @@ export default function TeacherView({ user }: Props) {
         const publishedIds = restoredContent.map((item) => item.id);
 
         setContent(restoredContent);
-        setImages(restoredImages);
+        // Initialize history for published-restored images
+        const imagesWithHistory: Record<string, ImageState> = {};
+        for (const [itemId, state] of Object.entries(restoredImages)) {
+          if (state.url) {
+            const cached = imageHistoryCache.get(itemId);
+            imagesWithHistory[itemId] = cached?.history?.length
+              ? { ...state, history: cached.history, historyIndex: cached.historyIndex }
+              : { ...state, history: [{ url: state.url, createdAt: new Date().toISOString() }], historyIndex: 0 };
+          } else {
+            imagesWithHistory[itemId] = state;
+          }
+        }
+        setImages(imagesWithHistory);
         setVideos(restoredVideos);
         setSelectedForPublish(new Set(publishedIds));
         setPublishedContentIds(new Set(publishedIds));
@@ -1141,7 +1213,7 @@ export default function TeacherView({ user }: Props) {
 
     setImages((prev) => {
       const next = { ...prev };
-      for (const item of pending) next[item.id] = { status: "loading" };
+      for (const item of pending) next[item.id] = { ...prev[item.id], status: "loading" };
       return next;
     });
 
@@ -1159,7 +1231,24 @@ export default function TeacherView({ user }: Props) {
           let data: Record<string, unknown>;
           try { data = JSON.parse(text); } catch { throw new Error("Image response was empty."); }
           if (!res.ok) throw new Error((data?.error as string) ?? "Failed to generate image.");
-          if (!cancelled) setImages((prev) => ({ ...prev, [item.id]: { status: "ready", url: data.url as string } }));
+          if (!cancelled) {
+            const newUrl = data.url as string;
+            setImages((prev) => {
+              // If history already exists (e.g. from cache), don't reset it
+              if (prev[item.id]?.history?.length) {
+                return { ...prev, [item.id]: { ...prev[item.id], status: "ready", url: newUrl } };
+              }
+              return {
+                ...prev,
+                [item.id]: {
+                  status: "ready",
+                  url: newUrl,
+                  history: [{ url: newUrl, createdAt: new Date().toISOString() }],
+                  historyIndex: 0,
+                },
+              };
+            });
+          }
         } catch (err) {
           if (!cancelled) setImages((prev) => ({ ...prev, [item.id]: { status: "error", error: err instanceof Error ? err.message : "Image failed." } }));
         }
@@ -1217,6 +1306,48 @@ export default function TeacherView({ user }: Props) {
     }
   };
 
+  const persistCurrentImage = async (itemId: string, imageUrl: string) => {
+    if (!classId || !assignmentId || !imageUrl) return;
+    try {
+      await fetch("/api/media", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          classId,
+          assignmentId,
+          studentId: "cohort",
+          contentItemId: itemId,
+          mediaType: "image",
+          mimeType: "image/webp",
+          dataUrl: imageUrl,
+        }),
+      });
+    } catch {
+      // Best-effort — don't block navigation
+    }
+  };
+
+  const navigateImageVersion = (itemId: string, direction: "prev" | "next") => {
+    const current = images[itemId];
+    if (!current?.history?.length) return;
+    const currentIndex = current.historyIndex ?? (current.history.length - 1);
+    const newIndex = direction === "prev"
+      ? Math.max(0, currentIndex - 1)
+      : Math.min(current.history.length - 1, currentIndex + 1);
+    if (newIndex === currentIndex) return;
+    const newUrl = current.history[newIndex].url;
+    setImages((prev) => ({
+      ...prev,
+      [itemId]: {
+        ...prev[itemId],
+        url: newUrl,
+        historyIndex: newIndex,
+      },
+    }));
+    // Update DB so gallery reflects the currently displayed version
+    void persistCurrentImage(itemId, newUrl);
+  };
+
   const [refineError, setRefineError] = useState<string | null>(null);
 
   const handleRefine = async () => {
@@ -1247,7 +1378,33 @@ export default function TeacherView({ user }: Props) {
       let data: Record<string, unknown>;
       try { data = JSON.parse(text); } catch { throw new Error("Image response was empty."); }
       if (!res.ok) throw new Error((data?.error as string) ?? "Failed to generate image.");
-      setImages((prev) => ({ ...prev, [refineTarget.itemId]: { status: "ready", url: data.url as string } }));
+      setImages((prev) => {
+        const current = prev[refineTarget.itemId];
+        const existingHistory = current?.history ?? [];
+        // Truncate after current index if user refined from a non-latest version
+        const baseHistory = current?.historyIndex !== undefined
+          ? existingHistory.slice(0, current.historyIndex + 1)
+          : existingHistory;
+        const newVersion: ImageVersion = {
+          url: data.url as string,
+          refinementPrompt: refinePrompt.trim(),
+          createdAt: new Date().toISOString(),
+        };
+        const newHistory = [...baseHistory, newVersion];
+        // Cap at MAX_IMAGE_VERSIONS — drop oldest entries
+        const cappedHistory = newHistory.length > MAX_IMAGE_VERSIONS
+          ? newHistory.slice(newHistory.length - MAX_IMAGE_VERSIONS)
+          : newHistory;
+        return {
+          ...prev,
+          [refineTarget.itemId]: {
+            status: "ready",
+            url: data.url as string,
+            history: cappedHistory,
+            historyIndex: cappedHistory.length - 1,
+          },
+        };
+      });
       setRefinePrompt("");
     } catch (err) {
       // Keep the current image intact — just show the error in the modal
@@ -1704,6 +1861,23 @@ export default function TeacherView({ user }: Props) {
                                   </div>
                                 )}
                               </div>
+                              {(images[item.id]?.history?.length ?? 0) > 1 && (
+                                <div className="flex items-center justify-center gap-1.5">
+                                  <button type="button" disabled={(images[item.id]?.historyIndex ?? 0) <= 0}
+                                    onClick={() => navigateImageVersion(item.id, "prev")}
+                                    className="rounded-full border border-slate-200 px-1.5 py-0.5 text-[10px] font-semibold text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:text-slate-300">
+                                    &#8592;
+                                  </button>
+                                  <span className="text-[10px] text-slate-500">
+                                    {(images[item.id]?.historyIndex ?? 0) + 1}/{images[item.id]?.history?.length ?? 0}
+                                  </span>
+                                  <button type="button" disabled={(images[item.id]?.historyIndex ?? 0) >= (images[item.id]?.history?.length ?? 1) - 1}
+                                    onClick={() => navigateImageVersion(item.id, "next")}
+                                    className="rounded-full border border-slate-200 px-1.5 py-0.5 text-[10px] font-semibold text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:text-slate-300">
+                                    &#8594;
+                                  </button>
+                                </div>
+                              )}
                               <div className="flex w-full gap-1.5">
                                 <button type="button" disabled={images[item.id]?.status !== "ready"} onClick={() => downloadFile(images[item.id]?.url ?? "", `${item.title.replace(/\s+/g, "-").toLowerCase()}-image.webp`)}
                                   className="flex w-1/2 items-center justify-center gap-1 rounded-lg border border-slate-200 bg-white px-2 py-1 text-[10px] font-semibold text-slate-600 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:text-slate-300">
@@ -1830,18 +2004,42 @@ export default function TeacherView({ user }: Props) {
               <p className="text-sm text-slate-500">{refineTarget.title}</p>
 
               {/* Image preview */}
-              <div className="flex items-center justify-center rounded-xl border border-slate-200 bg-slate-50">
-                {images[refineTarget.itemId]?.status === "ready" && images[refineTarget.itemId]?.url && (
-                  <img className="max-h-[40vh] w-full rounded-xl object-contain" src={images[refineTarget.itemId]?.url} alt={refineTarget.title} />
-                )}
-                {images[refineTarget.itemId]?.status === "loading" && (
-                  <div className="flex flex-col items-center gap-2 py-16">
-                    <span className="h-6 w-6 animate-spin rounded-full border-2 border-slate-300 border-t-slate-700" />
-                    <p className="text-sm text-slate-400">Generating refined image...</p>
+              <div className="flex flex-col gap-2">
+                <div className="flex items-center justify-center rounded-xl border border-slate-200 bg-slate-50">
+                  {images[refineTarget.itemId]?.status === "ready" && images[refineTarget.itemId]?.url && (
+                    <img className="max-h-[40vh] w-full rounded-xl object-contain" src={images[refineTarget.itemId]?.url} alt={refineTarget.title} />
+                  )}
+                  {images[refineTarget.itemId]?.status === "loading" && (
+                    <div className="flex flex-col items-center gap-2 py-16">
+                      <span className="h-6 w-6 animate-spin rounded-full border-2 border-slate-300 border-t-slate-700" />
+                      <p className="text-sm text-slate-400">Generating refined image...</p>
+                    </div>
+                  )}
+                  {images[refineTarget.itemId]?.status === "error" && (
+                    <p className="py-16 text-sm text-rose-500">{images[refineTarget.itemId]?.error}</p>
+                  )}
+                </div>
+                {(images[refineTarget.itemId]?.history?.length ?? 0) > 1 && (
+                  <div className="flex items-center justify-center gap-3">
+                    <button type="button" disabled={refineLoading || (images[refineTarget.itemId]?.historyIndex ?? 0) <= 0}
+                      onClick={() => navigateImageVersion(refineTarget.itemId, "prev")}
+                      className="rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:text-slate-300">
+                      &#8592; Prev
+                    </button>
+                    <span className="text-xs text-slate-500">
+                      Version {(images[refineTarget.itemId]?.historyIndex ?? 0) + 1} of {images[refineTarget.itemId]?.history?.length ?? 0}
+                    </span>
+                    <button type="button" disabled={refineLoading || (images[refineTarget.itemId]?.historyIndex ?? 0) >= (images[refineTarget.itemId]?.history?.length ?? 1) - 1}
+                      onClick={() => navigateImageVersion(refineTarget.itemId, "next")}
+                      className="rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:text-slate-300">
+                      Next &#8594;
+                    </button>
                   </div>
                 )}
-                {images[refineTarget.itemId]?.status === "error" && (
-                  <p className="py-16 text-sm text-rose-500">{images[refineTarget.itemId]?.error}</p>
+                {images[refineTarget.itemId]?.history?.[images[refineTarget.itemId]?.historyIndex ?? 0]?.refinementPrompt && (
+                  <p className="text-center text-xs italic text-slate-400 truncate">
+                    Refined: &ldquo;{images[refineTarget.itemId]?.history?.[images[refineTarget.itemId]?.historyIndex ?? 0]?.refinementPrompt}&rdquo;
+                  </p>
                 )}
               </div>
 

--- a/app/components/TeacherView.tsx
+++ b/app/components/TeacherView.tsx
@@ -195,6 +195,11 @@ export default function TeacherView({ user }: Props) {
   const [focusImage, setFocusImage] = useState<{ url: string; title: string } | null>(null);
   const [focusVideo, setFocusVideo] = useState<{ url: string; title: string } | null>(null);
 
+  // Refine modal
+  const [refineTarget, setRefineTarget] = useState<{ itemId: string; title: string } | null>(null);
+  const [refinePrompt, setRefinePrompt] = useState("");
+  const [refineLoading, setRefineLoading] = useState(false);
+
   // Content publishing
   const [selectedForPublish, setSelectedForPublish] = useState<Set<string>>(new Set());
   const [publishingContent, setPublishingContent] = useState(false);
@@ -1212,6 +1217,46 @@ export default function TeacherView({ user }: Props) {
     }
   };
 
+  const [refineError, setRefineError] = useState<string | null>(null);
+
+  const handleRefine = async () => {
+    if (!refineTarget || !refinePrompt.trim()) return;
+    const item = content.find((c) => c.id === refineTarget.itemId);
+    if (!item) return;
+
+    const currentImageUrl = images[refineTarget.itemId]?.url;
+    setRefineLoading(true);
+    setRefineError(null);
+
+    try {
+      const res = await fetch("/api/engagement-image", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          item,
+          plan,
+          answers: {},
+          classId,
+          assignmentId,
+          studentId: "cohort",
+          refinementPrompt: refinePrompt.trim(),
+          previousImageUrl: currentImageUrl,
+        }),
+      });
+      const text = await res.text();
+      let data: Record<string, unknown>;
+      try { data = JSON.parse(text); } catch { throw new Error("Image response was empty."); }
+      if (!res.ok) throw new Error((data?.error as string) ?? "Failed to generate image.");
+      setImages((prev) => ({ ...prev, [refineTarget.itemId]: { status: "ready", url: data.url as string } }));
+      setRefinePrompt("");
+    } catch (err) {
+      // Keep the current image intact — just show the error in the modal
+      setRefineError(err instanceof Error ? err.message : "Refine failed.");
+    } finally {
+      setRefineLoading(false);
+    }
+  };
+
 
   return (
     <div className="min-h-screen bg-slate-50 text-slate-900">
@@ -1659,10 +1704,16 @@ export default function TeacherView({ user }: Props) {
                                   </div>
                                 )}
                               </div>
-                              <button type="button" disabled={images[item.id]?.status !== "ready"} onClick={() => downloadFile(images[item.id]?.url ?? "", `${item.title.replace(/\s+/g, "-").toLowerCase()}-image.webp`)}
-                                className="flex w-full items-center justify-center gap-1 rounded-lg border border-slate-200 bg-white px-2 py-1 text-[10px] font-semibold text-slate-600 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:text-slate-300">
-                                Save image
-                              </button>
+                              <div className="flex w-full gap-1.5">
+                                <button type="button" disabled={images[item.id]?.status !== "ready"} onClick={() => downloadFile(images[item.id]?.url ?? "", `${item.title.replace(/\s+/g, "-").toLowerCase()}-image.webp`)}
+                                  className="flex w-1/2 items-center justify-center gap-1 rounded-lg border border-slate-200 bg-white px-2 py-1 text-[10px] font-semibold text-slate-600 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:text-slate-300">
+                                  Save
+                                </button>
+                                <button type="button" disabled={images[item.id]?.status !== "ready"} onClick={() => { setRefineTarget({ itemId: item.id, title: item.title }); setRefinePrompt(""); setRefineError(null); }}
+                                  className="flex w-1/2 items-center justify-center gap-1 rounded-lg border border-slate-200 bg-white px-2 py-1 text-[10px] font-semibold text-slate-600 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:text-slate-300">
+                                  Refine
+                                </button>
+                              </div>
                             </div>
                             <div className="flex w-32 shrink-0 flex-col gap-1.5 sm:w-36">
                               <div className="aspect-square w-full">
@@ -1690,10 +1741,16 @@ export default function TeacherView({ user }: Props) {
                                   </div>
                                 )}
                               </div>
-                              <button type="button" disabled={videos[item.id]?.status !== "ready"} onClick={() => downloadFile(videos[item.id]?.url ?? "", `${item.title.replace(/\s+/g, "-").toLowerCase()}-video.mp4`)}
-                                className="flex w-full items-center justify-center gap-1 rounded-lg border border-slate-200 bg-white px-2 py-1 text-[10px] font-semibold text-slate-600 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:text-slate-300">
-                                Save video
-                              </button>
+                              <div className="flex w-full gap-1.5">
+                                <button type="button" disabled={videos[item.id]?.status !== "ready"} onClick={() => downloadFile(videos[item.id]?.url ?? "", `${item.title.replace(/\s+/g, "-").toLowerCase()}-video.mp4`)}
+                                  className="flex w-1/2 items-center justify-center gap-1 rounded-lg border border-slate-200 bg-white px-2 py-1 text-[10px] font-semibold text-slate-600 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:text-slate-300">
+                                  Save
+                                </button>
+                                <button type="button" disabled={images[item.id]?.status !== "ready"} onClick={() => { setRefineTarget({ itemId: item.id, title: item.title }); setRefinePrompt(""); setRefineError(null); }}
+                                  className="flex w-1/2 items-center justify-center gap-1 rounded-lg border border-slate-200 bg-white px-2 py-1 text-[10px] font-semibold text-slate-600 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:text-slate-300">
+                                  Refine
+                                </button>
+                              </div>
                             </div>
                           </div>
 
@@ -1758,6 +1815,62 @@ export default function TeacherView({ user }: Props) {
               <button type="button" className="absolute right-2 top-2 z-10 rounded-full bg-white/90 px-3 py-1 text-xs font-semibold text-slate-700 shadow" onClick={() => setFocusVideo(null)}>Close</button>
               <video className="max-h-[80vh] w-full rounded-2xl bg-black shadow-2xl" src={focusVideo.url} controls autoPlay playsInline />
               <p className="mt-3 text-center text-sm text-slate-100">{focusVideo.title}</p>
+            </div>
+          </div>
+        )}
+
+        {/* Refine image modal */}
+        {refineTarget && (
+          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-6" role="dialog" aria-modal="true" onClick={() => { if (!refineLoading) setRefineTarget(null); }}>
+            <div className="relative flex w-full max-w-2xl flex-col gap-4 rounded-2xl bg-white p-6 shadow-2xl" onClick={(e) => e.stopPropagation()}>
+              <div className="flex items-center justify-between">
+                <h3 className="text-lg font-semibold text-slate-900">Refine Image</h3>
+                <button type="button" disabled={refineLoading} className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600 transition hover:bg-slate-200 disabled:cursor-not-allowed disabled:text-slate-300" onClick={() => setRefineTarget(null)}>Close</button>
+              </div>
+              <p className="text-sm text-slate-500">{refineTarget.title}</p>
+
+              {/* Image preview */}
+              <div className="flex items-center justify-center rounded-xl border border-slate-200 bg-slate-50">
+                {images[refineTarget.itemId]?.status === "ready" && images[refineTarget.itemId]?.url && (
+                  <img className="max-h-[40vh] w-full rounded-xl object-contain" src={images[refineTarget.itemId]?.url} alt={refineTarget.title} />
+                )}
+                {images[refineTarget.itemId]?.status === "loading" && (
+                  <div className="flex flex-col items-center gap-2 py-16">
+                    <span className="h-6 w-6 animate-spin rounded-full border-2 border-slate-300 border-t-slate-700" />
+                    <p className="text-sm text-slate-400">Generating refined image...</p>
+                  </div>
+                )}
+                {images[refineTarget.itemId]?.status === "error" && (
+                  <p className="py-16 text-sm text-rose-500">{images[refineTarget.itemId]?.error}</p>
+                )}
+              </div>
+
+              {/* Refinement input */}
+              {refineError && (
+                <div className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">{refineError}</div>
+              )}
+              <div className="relative">
+                <textarea
+                  value={refinePrompt}
+                  onChange={(e) => { setRefinePrompt(e.target.value.slice(0, 500)); setRefineError(null); }}
+                  placeholder="Describe how you'd like to modify this image..."
+                  rows={3}
+                  className="w-full resize-none rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 pr-16 text-sm text-slate-700 placeholder:text-slate-400 focus:border-slate-300 focus:outline-none focus:ring-2 focus:ring-slate-200"
+                />
+                <span className="absolute bottom-2 right-3 text-[10px] text-slate-400">{refinePrompt.length}/500</span>
+              </div>
+
+              {/* Actions */}
+              <div className="flex items-center justify-end gap-3">
+                <button type="button" disabled={refineLoading} onClick={() => setRefineTarget(null)}
+                  className="rounded-full border border-slate-200 px-4 py-2 text-xs font-semibold text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:text-slate-300">
+                  Cancel
+                </button>
+                <button type="button" disabled={refineLoading || !refinePrompt.trim()} onClick={handleRefine}
+                  className="rounded-full bg-[#BA0C2F] px-5 py-2 text-xs font-semibold text-white transition hover:bg-[#9a0a27] disabled:cursor-not-allowed disabled:bg-slate-400">
+                  {refineLoading ? "Regenerating..." : "Regenerate"}
+                </button>
+              </div>
             </div>
           </div>
         )}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -26,10 +26,18 @@ export type ContentItem = {
   visualBrief?: string;
 };
 
+export type ImageVersion = {
+  url: string;
+  refinementPrompt?: string;
+  createdAt: string;
+};
+
 export type ImageState = {
   status: "idle" | "loading" | "ready" | "error";
   url?: string;
   error?: string;
+  history?: ImageVersion[];
+  historyIndex?: number;
 };
 
 export type VideoState = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1219,13 +1219,13 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.10.tgz",
-      "integrity": "sha512-OnejAIVD+CxzyAUrVic7lG+3QRltyja9LoNqCE/1YVs8ichoTbJlVSaZ9iSMcnHLyzrSNtvaOGjSDRP+d/ouFA==",
+      "version": "3.972.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.4.tgz",
+      "integrity": "sha512-0zJ05ANfYqI6+rGqj8samZBFod0dPPousBjLEqg8WdxSgbMAkRgLyn81lP215Do0rFJ/17LIXwr7q0yK24mP6Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
-        "fast-xml-parser": "5.4.1",
+        "@smithy/types": "^4.12.0",
+        "fast-xml-parser": "5.3.4",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3909,9 +3909,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
-      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.12.0.tgz",
+      "integrity": "sha512-9YcuJVTOBDjg9LWo23Qp0lTQ3D7fQsQtwle0jVfpbUHy9qBwCEgKuVH4FqFB3VYu0nwdHKiEMA+oXz7oV8X1kw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4859,13 +4859,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.2"
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -5364,9 +5364,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6960,25 +6960,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-xml-builder": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.0.tgz",
-      "integrity": "sha512-7mtITW/we2/wTUZqMyBOR2F8xP4CRxMiSEcQxPIqdRWdO2L/HZSOlzoNyghmyDwNB8BDxePooV1ZTJpkOUhdRg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "path-expression-matcher": "^1.1.2"
-      }
-    },
     "node_modules/fast-xml-parser": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
-      "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.4.tgz",
+      "integrity": "sha512-EFd6afGmXlCx8H8WTZHhAoDaWaGyuIBoZJ2mknrNxug+aZKjkp0a0dlars9Izl+jF+7Gu1/5f/2h68cQpe0IiA==",
       "funding": [
         {
           "type": "github",
@@ -6987,8 +6972,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.0.0",
-        "strnum": "^2.1.2"
+        "strnum": "^2.1.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -8540,9 +8524,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -8970,21 +8954,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/path-expression-matcher": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.1.2.tgz",
-      "integrity": "sha512-LXWqJmcpp2BKOEmgt4CyuESFmBfPuhJlAHKJsFzuJU6CxErWk75BrO+Ni77M9OxHN6dCYKM4vj+21Z6cOL96YQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/path-key": {
@@ -9892,9 +9861,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
-      "integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
+      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1219,13 +1219,13 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.4.tgz",
-      "integrity": "sha512-0zJ05ANfYqI6+rGqj8samZBFod0dPPousBjLEqg8WdxSgbMAkRgLyn81lP215Do0rFJ/17LIXwr7q0yK24mP6Q==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.10.tgz",
+      "integrity": "sha512-OnejAIVD+CxzyAUrVic7lG+3QRltyja9LoNqCE/1YVs8ichoTbJlVSaZ9iSMcnHLyzrSNtvaOGjSDRP+d/ouFA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "fast-xml-parser": "5.3.4",
+        "@smithy/types": "^4.13.0",
+        "fast-xml-parser": "5.4.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3909,9 +3909,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.12.0.tgz",
-      "integrity": "sha512-9YcuJVTOBDjg9LWo23Qp0lTQ3D7fQsQtwle0jVfpbUHy9qBwCEgKuVH4FqFB3VYu0nwdHKiEMA+oXz7oV8X1kw==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4859,13 +4859,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -5364,9 +5364,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6960,10 +6960,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-xml-parser": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.4.tgz",
-      "integrity": "sha512-EFd6afGmXlCx8H8WTZHhAoDaWaGyuIBoZJ2mknrNxug+aZKjkp0a0dlars9Izl+jF+7Gu1/5f/2h68cQpe0IiA==",
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.0.tgz",
+      "integrity": "sha512-7mtITW/we2/wTUZqMyBOR2F8xP4CRxMiSEcQxPIqdRWdO2L/HZSOlzoNyghmyDwNB8BDxePooV1ZTJpkOUhdRg==",
       "funding": [
         {
           "type": "github",
@@ -6972,7 +6972,23 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^2.1.0"
+        "path-expression-matcher": "^1.1.2"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
+      "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.0.0",
+        "strnum": "^2.1.2"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -8524,9 +8540,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -8954,6 +8970,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.1.2.tgz",
+      "integrity": "sha512-LXWqJmcpp2BKOEmgt4CyuESFmBfPuhJlAHKJsFzuJU6CxErWk75BrO+Ni77M9OxHN6dCYKM4vj+21Z6cOL96YQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/path-key": {
@@ -9861,9 +9892,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
-      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
+      "integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
  ## Summary

  - Teachers can now browse all refined image versions using prev/next navigation

  - Selecting a version updates the gallery and video generation to use that version

  - History is preserved across SPA navigation (gallery → back)

  - Max 10 versions per image; refining from an older version truncates forward history



  ## Changes

  - `lib/types.ts`: Add `ImageVersion` type, extend `ImageState` with `history` and `historyIndex`

  - `app/components/TeacherView.tsx`: Version tracking, navigation UI, module-level cache, DB sync on

  version switch

  - `app/api/media/route.ts`: Add PUT endpoint to persist selected image version



  ## Validation

  - `npm run build` Pass

  - `npm run lint` 0 errors, 9 pre-existing warnings

  - `npm test` 64 passed

## More features will be added later