### PR TITLE
Handle strategy analysis timeouts gracefully

### DIFF
--- a/__tests__/api/strategy-batch.test.ts
+++ b/__tests__/api/strategy-batch.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createCompletion, MockAPIConnectionTimeoutError } = vi.hoisted(() => {
+  const createCompletion = vi.fn();
+
+  class MockAPIConnectionTimeoutError extends Error {
+    constructor(message = "Request timed out.") {
+      super(message);
+      this.name = "Error";
+    }
+  }
+
+  return { createCompletion, MockAPIConnectionTimeoutError };
+});
+
+vi.mock("openai", () => {
+  class MockOpenAI {
+    chat = {
+      completions: {
+        create: createCompletion,
+      },
+    };
+  }
+
+  return {
+    default: MockOpenAI,
+    APIConnectionTimeoutError: MockAPIConnectionTimeoutError,
+  };
+});
+
+vi.mock("@/lib/nosql", () => {
+  const cache = new Map<string, string>();
+
+  return {
+    getCachedPlanJson: vi.fn(async (classId: string, assignmentId: string, studentId: string) => {
+      return cache.get(`${classId}:${assignmentId}:${studentId}`) ?? null;
+    }),
+    upsertCachedPlanJson: vi.fn(async (classId: string, assignmentId: string, studentId: string, planJson: string) => {
+      cache.set(`${classId}:${assignmentId}:${studentId}`, planJson);
+    }),
+    __resetCache: () => {
+      cache.clear();
+    },
+  };
+});
+
+const { POST } = await import("@/app/api/strategy-batch/route");
+const { __resetCache } = (await import("@/lib/nosql")) as unknown as {
+  __resetCache: () => void;
+};
+
+const buildRequest = (students: Array<Record<string, unknown>>) =>
+  new Request("http://localhost:3000/api/strategy-batch", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      classId: "class-1",
+      assignmentId: "assignment-1",
+      students,
+    }),
+  });
+
+beforeEach(() => {
+  process.env.OPENAI_API_KEY = "test-key";
+  createCompletion.mockReset();
+  __resetCache();
+});
+
+describe("POST /api/strategy-batch", () => {
+  it("returns 504 and normalized timeout errors when every student times out", async () => {
+    createCompletion
+      .mockRejectedValueOnce(new MockAPIConnectionTimeoutError())
+      .mockRejectedValueOnce(new MockAPIConnectionTimeoutError());
+
+    const res = await POST(buildRequest([
+      { id: "student-1", name: "Jon", answers: { q1: "A", q2: "B" } },
+      { id: "student-2", name: "David", answers: { q1: "C", q2: "D" } },
+    ]));
+
+    expect(res.status).toBe(504);
+    const data = await res.json();
+    expect(data.error).toBe("Strategy generation timed out before the model returned.");
+    expect(data.errors).toEqual([
+      {
+        id: "student-1",
+        name: "Jon",
+        error: "Strategy generation timed out before the model returned.",
+      },
+      {
+        id: "student-2",
+        name: "David",
+        error: "Strategy generation timed out before the model returned.",
+      },
+    ]);
+  });
+
+  it("returns partial results when one student succeeds and another times out", async () => {
+    createCompletion
+      .mockResolvedValueOnce({
+        choices: [
+          {
+            message: {
+              content: JSON.stringify({
+                name: "Bridge to prior knowledge",
+                strategy: "experience bridging",
+                relevance: {
+                  "cognitive conflict": 10,
+                  analogy: 15,
+                  "experience bridging": 90,
+                  "engaged critiquing": 20,
+                },
+                overallRecommendation: "Connect the concept to the student's experience.",
+                recommendationReason: "This fits Ava because she referenced a concrete real-world example.",
+                summary: "Use prior experience to ground the lesson.",
+                tldr: "Anchor the lesson in familiar experiences.",
+                rationale: "Ava named a concrete example from daily life.",
+                tactics: ["Start with a familiar example."],
+                cadence: "At lesson launch",
+                checks: ["Ask Ava to compare the example to the new concept."],
+              }),
+            },
+          },
+        ],
+      })
+      .mockRejectedValueOnce(new MockAPIConnectionTimeoutError());
+
+    const res = await POST(buildRequest([
+      { id: "student-1", name: "Ava", answers: { q1: "A", q2: "B" } },
+      { id: "student-2", name: "Jon", answers: { q1: "C", q2: "D" } },
+    ]));
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.results).toHaveLength(1);
+    expect(data.results[0]).toMatchObject({
+      id: "student-1",
+      name: "Ava",
+      plan: {
+        strategy: "experience bridging",
+      },
+    });
+    expect(data.distribution).toEqual({ "experience bridging": 1 });
+    expect(data.errors).toEqual([
+      {
+        id: "student-2",
+        name: "Jon",
+        error: "Strategy generation timed out before the model returned.",
+      },
+    ]);
+  });
+});

--- a/app/api/strategy-batch/route.ts
+++ b/app/api/strategy-batch/route.ts
@@ -1,4 +1,4 @@
-import OpenAI from "openai";
+import OpenAI, { APIConnectionTimeoutError } from "openai";
 import { NextResponse } from "next/server";
 
 import { getCachedPlanJson, upsertCachedPlanJson } from "@/lib/nosql";
@@ -41,7 +41,7 @@ type StudentStrategyError = {
 export const runtime = "nodejs";
 export const maxDuration = 60;
 
-const STRATEGY_REQUEST_TIMEOUT_MS = 25_000;
+const STRATEGY_REQUEST_TIMEOUT_MS = 45_000;
 
 const buildPrompt = (student: Student) => ({
   system: `You are an education engagement planner.
@@ -109,7 +109,10 @@ const ensurePlanFields = (plan: Plan) => {
 };
 
 const isTimeoutError = (error: unknown) =>
-  error instanceof Error && error.name === "APIConnectionTimeoutError";
+  error instanceof APIConnectionTimeoutError ||
+  (error instanceof Error &&
+    (error.constructor.name === "APIConnectionTimeoutError" ||
+      error.message === "Request timed out."));
 
 const buildStudentError = (student: Student, error: unknown): StudentStrategyError => ({
   id: student.id,
@@ -203,32 +206,23 @@ export async function POST(request: Request) {
     }
 
     const model = process.env.OPENAI_MODEL ?? "gpt-5-nano";
-    const settled = await Promise.allSettled(
-      students.map((student) =>
-        generatePlanForStudent({
+    const results: StudentStrategyResult[] = [];
+    const errors: StudentStrategyError[] = [];
+
+    for (const student of students) {
+      try {
+        const result = await generatePlanForStudent({
           client,
           model,
           classKey,
           assignmentKey,
           student,
-        }),
-      ),
-    );
-
-    const results: StudentStrategyResult[] = [];
-    const errors: StudentStrategyError[] = [];
-
-    settled.forEach((result, index) => {
-      const student = students[index];
-      if (!student) return;
-
-      if (result.status === "fulfilled") {
-        results.push(result.value);
-        return;
+        });
+        results.push(result);
+      } catch (error) {
+        errors.push(buildStudentError(student, error));
       }
-
-      errors.push(buildStudentError(student, result.reason));
-    });
+    }
 
     const distribution: Record<string, number> = {};
     results.forEach((result) => {
@@ -250,8 +244,7 @@ export async function POST(request: Request) {
       { status: timedOut ? 504 : 500 },
     );
   } catch (error) {
-    const isUpstreamTimeout =
-      error instanceof Error && error.name === "APIConnectionTimeoutError";
+    const isUpstreamTimeout = isTimeoutError(error);
     const message =
       isUpstreamTimeout
         ? "Strategy generation timed out before the model returned."

--- a/app/api/strategy-batch/route.ts
+++ b/app/api/strategy-batch/route.ts
@@ -27,6 +27,9 @@ type Plan = {
 };
 
 export const runtime = "nodejs";
+export const maxDuration = 60;
+
+const STRATEGY_REQUEST_TIMEOUT_MS = 25_000;
 
 const buildPrompt = (student: Student) => ({
   system: `You are an education engagement planner.
@@ -102,7 +105,11 @@ export async function POST(request: Request) {
   }
 
   try {
-    const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+    const client = new OpenAI({
+      apiKey: process.env.OPENAI_API_KEY,
+      timeout: STRATEGY_REQUEST_TIMEOUT_MS,
+      maxRetries: 0,
+    });
     const {
       students = [],
       classId,
@@ -169,9 +176,18 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ results, distribution });
   } catch (error) {
+    const isUpstreamTimeout =
+      error instanceof Error && error.name === "APIConnectionTimeoutError";
     const message =
-      error instanceof Error ? error.message : "Failed to analyze students.";
-    console.error("strategy-batch error:", message);
-    return NextResponse.json({ error: message }, { status: 500 });
+      isUpstreamTimeout
+        ? "Strategy generation timed out before the model returned."
+        : error instanceof Error
+          ? error.message
+          : "Failed to analyze students.";
+    console.error("strategy-batch error:", message, error);
+    return NextResponse.json(
+      { error: message },
+      { status: isUpstreamTimeout ? 504 : 500 },
+    );
   }
 }

--- a/app/api/strategy-batch/route.ts
+++ b/app/api/strategy-batch/route.ts
@@ -26,6 +26,18 @@ type Plan = {
   checks: string[];
 };
 
+type StudentStrategyResult = {
+  id: string;
+  name: string;
+  plan: Plan;
+};
+
+type StudentStrategyError = {
+  id: string;
+  name: string;
+  error: string;
+};
+
 export const runtime = "nodejs";
 export const maxDuration = 60;
 
@@ -96,6 +108,68 @@ const ensurePlanFields = (plan: Plan) => {
   return plan;
 };
 
+const isTimeoutError = (error: unknown) =>
+  error instanceof Error && error.name === "APIConnectionTimeoutError";
+
+const buildStudentError = (student: Student, error: unknown): StudentStrategyError => ({
+  id: student.id,
+  name: student.name,
+  error: isTimeoutError(error)
+    ? "Strategy generation timed out before the model returned."
+    : error instanceof Error
+      ? error.message
+      : `Failed to analyze ${student.name}.`,
+});
+
+const generatePlanForStudent = async ({
+  client,
+  model,
+  classKey,
+  assignmentKey,
+  student,
+}: {
+  client: OpenAI;
+  model: string;
+  classKey: string;
+  assignmentKey: string;
+  student: Student;
+}): Promise<StudentStrategyResult> => {
+  const cachedPlanJson = await getCachedPlanJson(
+    classKey,
+    assignmentKey,
+    student.id,
+  );
+  if (cachedPlanJson) {
+    const cachedPlan = JSON.parse(cachedPlanJson) as Plan;
+    cachedPlan.strategy = normalizeStrategy(cachedPlan.strategy);
+    const plan = ensurePlanFields(cachedPlan);
+    return { id: student.id, name: student.name, plan };
+  }
+
+  const prompt = buildPrompt(student);
+  const completion = await client.chat.completions.create({
+    model,
+    response_format: { type: "json_object" },
+    messages: [
+      { role: "system", content: prompt.system },
+      { role: "user", content: prompt.user },
+    ],
+  });
+
+  const parsedPlan = parseJson(completion.choices[0]?.message?.content);
+  parsedPlan.strategy = normalizeStrategy(parsedPlan.strategy);
+  const plan = ensurePlanFields(parsedPlan);
+
+  await upsertCachedPlanJson(
+    classKey,
+    assignmentKey,
+    student.id,
+    JSON.stringify(plan),
+  );
+
+  return { id: student.id, name: student.name, plan };
+};
+
 export async function POST(request: Request) {
   if (!process.env.OPENAI_API_KEY) {
     return NextResponse.json(
@@ -129,44 +203,32 @@ export async function POST(request: Request) {
     }
 
     const model = process.env.OPENAI_MODEL ?? "gpt-5-nano";
-    const results: Array<{ id: string; name: string; plan: Plan }> = [];
+    const settled = await Promise.allSettled(
+      students.map((student) =>
+        generatePlanForStudent({
+          client,
+          model,
+          classKey,
+          assignmentKey,
+          student,
+        }),
+      ),
+    );
 
-    for (const student of students) {
-      const cachedPlanJson = await getCachedPlanJson(
-        classKey,
-        assignmentKey,
-        student.id,
-      );
-      if (cachedPlanJson) {
-        const cachedPlan = JSON.parse(cachedPlanJson) as Plan;
-        cachedPlan.strategy = normalizeStrategy(cachedPlan.strategy);
-        const plan = ensurePlanFields(cachedPlan);
-        results.push({ id: student.id, name: student.name, plan });
-        continue;
+    const results: StudentStrategyResult[] = [];
+    const errors: StudentStrategyError[] = [];
+
+    settled.forEach((result, index) => {
+      const student = students[index];
+      if (!student) return;
+
+      if (result.status === "fulfilled") {
+        results.push(result.value);
+        return;
       }
 
-      const prompt = buildPrompt(student);
-      const completion = await client.chat.completions.create({
-        model,
-        response_format: { type: "json_object" },
-        messages: [
-          { role: "system", content: prompt.system },
-          { role: "user", content: prompt.user },
-        ],
-      });
-
-      const parsedPlan = parseJson(completion.choices[0]?.message?.content);
-      parsedPlan.strategy = normalizeStrategy(parsedPlan.strategy);
-      const plan = ensurePlanFields(parsedPlan);
-      results.push({ id: student.id, name: student.name, plan });
-
-      await upsertCachedPlanJson(
-        classKey,
-        assignmentKey,
-        student.id,
-        JSON.stringify(plan),
-      );
-    }
+      errors.push(buildStudentError(student, result.reason));
+    });
 
     const distribution: Record<string, number> = {};
     results.forEach((result) => {
@@ -174,7 +236,19 @@ export async function POST(request: Request) {
       distribution[key] = (distribution[key] ?? 0) + 1;
     });
 
-    return NextResponse.json({ results, distribution });
+    if (results.length > 0) {
+      return NextResponse.json({ results, distribution, errors });
+    }
+
+    const firstError = errors[0]?.error ?? "Failed to analyze students.";
+    const timedOut = errors.every((error) =>
+      error.error === "Strategy generation timed out before the model returned.",
+    );
+
+    return NextResponse.json(
+      { error: firstError, errors, distribution },
+      { status: timedOut ? 504 : 500 },
+    );
   } catch (error) {
     const isUpstreamTimeout =
       error instanceof Error && error.name === "APIConnectionTimeoutError";

--- a/app/api/strategy-single/route.ts
+++ b/app/api/strategy-single/route.ts
@@ -27,6 +27,9 @@ type Plan = {
 };
 
 export const runtime = "nodejs";
+export const maxDuration = 60;
+
+const STRATEGY_REQUEST_TIMEOUT_MS = 25_000;
 
 const buildPrompt = (student: Student) => ({
   system: `You are an education engagement planner.
@@ -102,7 +105,11 @@ export async function POST(request: Request) {
   }
 
   try {
-    const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+    const client = new OpenAI({
+      apiKey: process.env.OPENAI_API_KEY,
+      timeout: STRATEGY_REQUEST_TIMEOUT_MS,
+      maxRetries: 0,
+    });
     const { student, classId, assignmentId } = (await request.json()) as {
       student: Student;
       classId?: string;
@@ -159,9 +166,18 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ plan });
   } catch (error) {
+    const isUpstreamTimeout =
+      error instanceof Error && error.name === "APIConnectionTimeoutError";
     const message =
-      error instanceof Error ? error.message : "Failed to analyze student.";
-    console.error("strategy-single error:", message);
-    return NextResponse.json({ error: message }, { status: 500 });
+      isUpstreamTimeout
+        ? "Strategy generation timed out before the model returned."
+        : error instanceof Error
+          ? error.message
+          : "Failed to analyze student.";
+    console.error("strategy-single error:", message, error);
+    return NextResponse.json(
+      { error: message },
+      { status: isUpstreamTimeout ? 504 : 500 },
+    );
   }
 }

--- a/app/api/strategy-single/route.ts
+++ b/app/api/strategy-single/route.ts
@@ -29,7 +29,7 @@ type Plan = {
 export const runtime = "nodejs";
 export const maxDuration = 60;
 
-const STRATEGY_REQUEST_TIMEOUT_MS = 25_000;
+const STRATEGY_REQUEST_TIMEOUT_MS = 45_000;
 
 const buildPrompt = (student: Student) => ({
   system: `You are an education engagement planner.

--- a/app/components/TeacherView.tsx
+++ b/app/components/TeacherView.tsx
@@ -163,6 +163,44 @@ const CONTENT_TEXT_MODE_LABELS: Record<TextMode, string> = {
 const isTextModeValue = (value: string): value is TextMode =>
   value === "questions" || value === "phenomenon" || value === "dialogue";
 
+const parseJsonResponse = async <T,>(response: Response): Promise<T | null> => {
+  const text = await response.text();
+  if (!text.trim()) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    return null;
+  }
+};
+
+const delay = (ms: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+const formatStrategyRequestError = (
+  studentName: string,
+  status: number,
+  message?: string,
+) => {
+  if (message) {
+    return message;
+  }
+
+  if (status === 504) {
+    return `Timed out analyzing ${studentName}. The server did not finish before the gateway timeout. Try again; cached students will be reused.`;
+  }
+
+  if (status === 502 || status === 503) {
+    return `The server was temporarily unavailable while analyzing ${studentName}. Try again.`;
+  }
+
+  return `Failed to analyze ${studentName} (HTTP ${status}).`;
+};
+
 const getContentModeLabels = (item: ContentItem) => {
   if (item.textModes && item.textModes.length > 0) {
     return item.textModes.map((mode) => CONTENT_TEXT_MODE_LABELS[mode] ?? mode);
@@ -1032,14 +1070,49 @@ export default function TeacherView({ user }: Props) {
           total: studentsForApi.length,
           currentName: `Generating ${student.name}...`,
         });
-        const res = await fetch("/api/strategy-single", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ student, classId, assignmentId }),
-        });
-        const data = await res.json();
-        if (!res.ok) throw new Error(data?.error ?? `Failed to analyze ${student.name}.`);
-        results.push({ id: student.id, name: student.name, plan: data.plan });
+        let plan: Plan | null = null;
+
+        for (let attempt = 1; attempt <= 2; attempt += 1) {
+          const res = await fetch("/api/strategy-single", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ student, classId, assignmentId }),
+          });
+          const data = await parseJsonResponse<{ error?: string; plan?: Plan }>(res);
+
+          if (res.ok && data?.plan) {
+            plan = data.plan;
+            break;
+          }
+
+          const isRetryable =
+            res.status === 502 || res.status === 503 || res.status === 504;
+          if (isRetryable && attempt < 2) {
+            setCohortProgress({
+              processed: index,
+              total: studentsForApi.length,
+              currentName: `Retrying ${student.name} after HTTP ${res.status}...`,
+            });
+            await delay(1000 * attempt);
+            continue;
+          }
+
+          if (!res.ok) {
+            throw new Error(
+              formatStrategyRequestError(student.name, res.status, data?.error),
+            );
+          }
+
+          throw new Error(
+            `Failed to analyze ${student.name}. The server returned an invalid response.`,
+          );
+        }
+
+        if (!plan) {
+          throw new Error(`Failed to analyze ${student.name}.`);
+        }
+
+        results.push({ id: student.id, name: student.name, plan });
         setCohortResults([...results]);
       }
 

--- a/app/components/TeacherView.tsx
+++ b/app/components/TeacherView.tsx
@@ -39,6 +39,16 @@ type PublishedContentPayloadItem = {
   media?: SharedContentMedia;
 };
 
+type StrategyBatchResponse = {
+  results?: StudentStrategyResult[];
+  distribution?: Record<string, number>;
+  errors?: Array<{ id?: string; name?: string; error?: string }>;
+  error?: string;
+};
+
+const COHORT_ANALYSIS_CHUNK_SIZE = 3;
+const COHORT_ANALYSIS_MAX_ATTEMPTS = 2;
+
 const collectPublishedMedia = (
   items: PublishedContentPayloadItem[] | undefined,
   contentIds: Set<string>,
@@ -181,8 +191,7 @@ const delay = (ms: number) =>
     setTimeout(resolve, ms);
   });
 
-const formatStrategyRequestError = (
-  studentName: string,
+const formatStrategyBatchError = (
   status: number,
   message?: string,
 ) => {
@@ -191,14 +200,24 @@ const formatStrategyRequestError = (
   }
 
   if (status === 504) {
-    return `Timed out analyzing ${studentName}. The server did not finish before the gateway timeout. Try again; cached students will be reused.`;
+    return "A cohort analysis batch timed out before the server could finish. Try again; cached students will be reused.";
   }
 
   if (status === 502 || status === 503) {
-    return `The server was temporarily unavailable while analyzing ${studentName}. Try again.`;
+    return "The server was temporarily unavailable during cohort analysis. Try again.";
   }
 
-  return `Failed to analyze ${studentName} (HTTP ${status}).`;
+  return `Cohort analysis failed (HTTP ${status}).`;
+};
+
+const chunkItems = <T,>(items: T[], size: number) => {
+  const chunks: T[][] = [];
+
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+
+  return chunks;
 };
 
 const getContentModeLabels = (item: ContentItem) => {
@@ -1008,6 +1027,20 @@ export default function TeacherView({ user }: Props) {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentStep, quizStatus, classId, assignmentId]);
 
+  useEffect(() => {
+    if (!loadingCohort) {
+      return;
+    }
+
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = "";
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, [loadingCohort]);
+
   const requestCohortAnalysis = async () => {
     if (!classId || !assignmentId) return;
     if (studentAnswers.length === 0) {
@@ -1049,72 +1082,121 @@ export default function TeacherView({ user }: Props) {
         }
       }
 
-      const results: StudentStrategyResult[] = [];
-      for (let index = 0; index < studentsForApi.length; index += 1) {
-        const student = studentsForApi[index];
+      const resultsMap = new Map<string, StudentStrategyResult>();
+      for (const student of studentsForApi) {
         const cached = cachedMap.get(student.id);
+        if (!cached) continue;
+        resultsMap.set(student.id, { id: student.id, name: student.name, plan: cached });
+      }
 
-        if (cached) {
-          results.push({ id: student.id, name: student.name, plan: cached });
+      const initialResults = studentsForApi
+        .filter((student) => resultsMap.has(student.id))
+        .map((student) => resultsMap.get(student.id) as StudentStrategyResult);
+      setCohortResults(initialResults);
+      setCohortProgress({
+        processed: initialResults.length,
+        total: studentsForApi.length,
+        currentName:
+          initialResults.length > 0
+            ? `Loaded ${initialResults.length} cached student${initialResults.length === 1 ? "" : "s"}.`
+            : "Starting cohort analysis...",
+      });
+
+      const uncachedStudents = studentsForApi.filter(
+        (student) => !cachedMap.has(student.id),
+      );
+      const studentChunks = chunkItems(
+        uncachedStudents,
+        COHORT_ANALYSIS_CHUNK_SIZE,
+      );
+
+      for (let chunkIndex = 0; chunkIndex < studentChunks.length; chunkIndex += 1) {
+        let pendingStudents = studentChunks[chunkIndex];
+
+        for (let attempt = 1; attempt <= COHORT_ANALYSIS_MAX_ATTEMPTS; attempt += 1) {
+          const batchStart = chunkIndex * COHORT_ANALYSIS_CHUNK_SIZE + 1;
+          const batchEnd = Math.min(
+            batchStart + pendingStudents.length - 1,
+            uncachedStudents.length,
+          );
+
           setCohortProgress({
-            processed: index + 1,
+            processed: resultsMap.size,
             total: studentsForApi.length,
-            currentName: `Loaded ${student.name} (cached)`,
+            currentName:
+              attempt === 1
+                ? `Analyzing batch ${chunkIndex + 1} of ${studentChunks.length} (${batchStart}-${batchEnd} of ${uncachedStudents.length} uncached students)...`
+                : `Retrying ${pendingStudents.length} student${pendingStudents.length === 1 ? "" : "s"} in batch ${chunkIndex + 1} of ${studentChunks.length}...`,
           });
-          setCohortResults([...results]);
-          continue;
-        }
 
-        setCohortProgress({
-          processed: index,
-          total: studentsForApi.length,
-          currentName: `Generating ${student.name}...`,
-        });
-        let plan: Plan | null = null;
-
-        for (let attempt = 1; attempt <= 2; attempt += 1) {
-          const res = await fetch("/api/strategy-single", {
+          const res = await fetch("/api/strategy-batch", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ student, classId, assignmentId }),
+            body: JSON.stringify({
+              students: pendingStudents,
+              classId,
+              assignmentId,
+            }),
           });
-          const data = await parseJsonResponse<{ error?: string; plan?: Plan }>(res);
+          const data = await parseJsonResponse<StrategyBatchResponse>(res);
 
-          if (res.ok && data?.plan) {
-            plan = data.plan;
+          for (const result of data?.results ?? []) {
+            resultsMap.set(result.id, result);
+          }
+
+          const orderedResults = studentsForApi
+            .filter((student) => resultsMap.has(student.id))
+            .map((student) => resultsMap.get(student.id) as StudentStrategyResult);
+          setCohortResults(orderedResults);
+          setCohortProgress({
+            processed: orderedResults.length,
+            total: studentsForApi.length,
+            currentName:
+              orderedResults.length < studentsForApi.length
+                ? `Completed ${orderedResults.length} of ${studentsForApi.length} students.`
+                : "Finalizing cohort recommendation...",
+          });
+
+          const failedStudents = pendingStudents.filter((student) =>
+            (data?.errors ?? []).some((error) => error.id === student.id),
+          );
+
+          if (res.ok && failedStudents.length === 0) {
             break;
           }
 
           const isRetryable =
-            res.status === 502 || res.status === 503 || res.status === 504;
-          if (isRetryable && attempt < 2) {
-            setCohortProgress({
-              processed: index,
-              total: studentsForApi.length,
-              currentName: `Retrying ${student.name} after HTTP ${res.status}...`,
-            });
+            res.status === 0 ||
+            res.status === 502 ||
+            res.status === 503 ||
+            res.status === 504 ||
+            failedStudents.length > 0;
+          if (isRetryable && attempt < COHORT_ANALYSIS_MAX_ATTEMPTS) {
+            pendingStudents = failedStudents.length > 0 ? failedStudents : pendingStudents;
             await delay(1000 * attempt);
             continue;
           }
 
-          if (!res.ok) {
+          if (failedStudents.length > 0) {
+            const failedNames = failedStudents.map((student) => student.name).join(", ");
             throw new Error(
-              formatStrategyRequestError(student.name, res.status, data?.error),
+              `Failed to analyze ${failedStudents.length} student${failedStudents.length === 1 ? "" : "s"} after retry: ${failedNames}.`,
             );
           }
 
-          throw new Error(
-            `Failed to analyze ${student.name}. The server returned an invalid response.`,
-          );
-        }
+          if (!res.ok) {
+            throw new Error(
+              formatStrategyBatchError(res.status, data?.error),
+            );
+          }
 
-        if (!plan) {
-          throw new Error(`Failed to analyze ${student.name}.`);
+          throw new Error("Cohort analysis returned an invalid response.");
         }
-
-        results.push({ id: student.id, name: student.name, plan });
-        setCohortResults([...results]);
       }
+
+      const results = studentsForApi
+        .filter((student) => resultsMap.has(student.id))
+        .map((student) => resultsMap.get(student.id) as StudentStrategyResult);
 
       const distribution = buildCohortDistribution(results);
       const masterPlan = buildCohortMasterPlan(results, distribution);
@@ -1563,6 +1645,10 @@ export default function TeacherView({ user }: Props) {
                     <div className="flex items-center gap-2 text-xs text-slate-500">
                       <span className="h-4 w-4 animate-spin rounded-full border-2 border-slate-300 border-t-slate-700" />
                       {cohortProgress.currentName || "Loading..."}
+                    </div>
+                    <div className="flex items-center justify-between text-xs font-semibold text-slate-500">
+                      <span>Do not refresh this page while cohort analysis is running.</span>
+                      <span>{Math.round((cohortProgress.processed / Math.max(1, cohortProgress.total)) * 100)}%</span>
                     </div>
                     <div className="h-2 w-full overflow-hidden rounded-full bg-slate-200">
                       <div className="h-full rounded-full bg-slate-700 transition-all" style={{ width: `${Math.round((cohortProgress.processed / Math.max(1, cohortProgress.total)) * 100)}%` }} />

--- a/app/components/TeacherView.tsx
+++ b/app/components/TeacherView.tsx
@@ -46,7 +46,7 @@ type StrategyBatchResponse = {
   error?: string;
 };
 
-const COHORT_ANALYSIS_CHUNK_SIZE = 3;
+const COHORT_ANALYSIS_CHUNK_SIZE = 1;
 const COHORT_ANALYSIS_MAX_ATTEMPTS = 2;
 
 const collectPublishedMedia = (


### PR DESCRIPTION
## Summary
- add explicit execution budget and upstream request timeout handling to the strategy routes
- return JSON 504 responses for upstream model timeouts instead of opaque 500s/timeouts
- make cohort analysis resilient to empty 504 bodies with safe JSON parsing and a retry on transient 502/503/504 responses

## Testing
- npm run lint -- app/api/strategy-single/route.ts app/api/strategy-batch/route.ts app/components/TeacherView.tsx
- npx tsc --noEmit
- npm run build *(fails in this environment because `next/font` could not fetch Geist and Geist Mono from Google Fonts)*