### PR TITLE
Improve cohort analysis throughput for 15-student cohorts

### DIFF
--- a/__tests__/api/strategy-batch.test.ts
+++ b/__tests__/api/strategy-batch.test.ts
@@ -66,6 +66,33 @@ beforeEach(() => {
   __resetCache();
 });
 
+const buildCompletion = (strategy = "experience bridging") => ({
+  choices: [
+    {
+      message: {
+        content: JSON.stringify({
+          name: "Bridge to prior knowledge",
+          strategy,
+          relevance: {
+            "cognitive conflict": strategy === "cognitive conflict" ? 90 : 10,
+            analogy: strategy === "analogy" ? 90 : 15,
+            "experience bridging": strategy === "experience bridging" ? 90 : 20,
+            "engaged critiquing": strategy === "engaged critiquing" ? 90 : 25,
+          },
+          overallRecommendation: "Connect the concept to the student's experience.",
+          recommendationReason: "This fits the student because they referenced a concrete real-world example.",
+          summary: "Use prior experience to ground the lesson.",
+          tldr: "Anchor the lesson in familiar experiences.",
+          rationale: "The student named a concrete example from daily life.",
+          tactics: ["Start with a familiar example."],
+          cadence: "At lesson launch",
+          checks: ["Ask the student to compare the example to the new concept."],
+        }),
+      },
+    },
+  ],
+});
+
 describe("POST /api/strategy-batch", () => {
   it("returns 504 and normalized timeout errors when every student times out", async () => {
     createCompletion
@@ -96,32 +123,7 @@ describe("POST /api/strategy-batch", () => {
 
   it("returns partial results when one student succeeds and another times out", async () => {
     createCompletion
-      .mockResolvedValueOnce({
-        choices: [
-          {
-            message: {
-              content: JSON.stringify({
-                name: "Bridge to prior knowledge",
-                strategy: "experience bridging",
-                relevance: {
-                  "cognitive conflict": 10,
-                  analogy: 15,
-                  "experience bridging": 90,
-                  "engaged critiquing": 20,
-                },
-                overallRecommendation: "Connect the concept to the student's experience.",
-                recommendationReason: "This fits Ava because she referenced a concrete real-world example.",
-                summary: "Use prior experience to ground the lesson.",
-                tldr: "Anchor the lesson in familiar experiences.",
-                rationale: "Ava named a concrete example from daily life.",
-                tactics: ["Start with a familiar example."],
-                cadence: "At lesson launch",
-                checks: ["Ask Ava to compare the example to the new concept."],
-              }),
-            },
-          },
-        ],
-      })
+      .mockResolvedValueOnce(buildCompletion("experience bridging"))
       .mockRejectedValueOnce(new MockAPIConnectionTimeoutError());
 
     const res = await POST(buildRequest([
@@ -147,5 +149,36 @@ describe("POST /api/strategy-batch", () => {
         error: "Strategy generation timed out before the model returned.",
       },
     ]);
+  });
+
+  it("starts multiple student generations in parallel within a batch", async () => {
+    const resolvers: Array<(value: unknown) => void> = [];
+    createCompletion.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvers.push(resolve);
+        }),
+    );
+
+    const requestPromise = POST(buildRequest([
+      { id: "student-1", name: "Ava", answers: { q1: "A", q2: "B" } },
+      { id: "student-2", name: "Jon", answers: { q1: "C", q2: "D" } },
+      { id: "student-3", name: "David", answers: { q1: "E", q2: "F" } },
+      { id: "student-4", name: "Mia", answers: { q1: "G", q2: "H" } },
+    ]));
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(createCompletion).toHaveBeenCalledTimes(4);
+
+    resolvers.forEach((resolve, index) => {
+      resolve(buildCompletion(index % 2 === 0 ? "experience bridging" : "analogy"));
+    });
+
+    const res = await requestPromise;
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.results).toHaveLength(4);
+    expect(data.errors).toEqual([]);
   });
 });

--- a/app/api/strategy-batch/route.ts
+++ b/app/api/strategy-batch/route.ts
@@ -42,6 +42,7 @@ export const runtime = "nodejs";
 export const maxDuration = 60;
 
 const STRATEGY_REQUEST_TIMEOUT_MS = 45_000;
+const STRATEGY_BATCH_CONCURRENCY = 4;
 
 const buildPrompt = (student: Student) => ({
   system: `You are an education engagement planner.
@@ -108,13 +109,26 @@ const ensurePlanFields = (plan: Plan) => {
   return plan;
 };
 
+const chunkItems = <T,>(items: T[], size: number) => {
+  const chunks: T[][] = [];
+
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+
+  return chunks;
+};
+
 const isTimeoutError = (error: unknown) =>
   error instanceof APIConnectionTimeoutError ||
   (error instanceof Error &&
     (error.constructor.name === "APIConnectionTimeoutError" ||
       error.message === "Request timed out."));
 
-const buildStudentError = (student: Student, error: unknown): StudentStrategyError => ({
+const buildStudentError = (
+  student: Student,
+  error: unknown,
+): StudentStrategyError => ({
   id: student.id,
   name: student.name,
   error: isTimeoutError(error)
@@ -182,6 +196,7 @@ export async function POST(request: Request) {
   }
 
   try {
+    const startedAt = Date.now();
     const client = new OpenAI({
       apiKey: process.env.OPENAI_API_KEY,
       timeout: STRATEGY_REQUEST_TIMEOUT_MS,
@@ -209,18 +224,29 @@ export async function POST(request: Request) {
     const results: StudentStrategyResult[] = [];
     const errors: StudentStrategyError[] = [];
 
-    for (const student of students) {
-      try {
-        const result = await generatePlanForStudent({
-          client,
-          model,
-          classKey,
-          assignmentKey,
-          student,
-        });
-        results.push(result);
-      } catch (error) {
-        errors.push(buildStudentError(student, error));
+    const studentChunks = chunkItems(students, STRATEGY_BATCH_CONCURRENCY);
+    for (const studentChunk of studentChunks) {
+      const settledResults = await Promise.allSettled(
+        studentChunk.map((student) =>
+          generatePlanForStudent({
+            client,
+            model,
+            classKey,
+            assignmentKey,
+            student,
+          }),
+        ),
+      );
+
+      for (let index = 0; index < settledResults.length; index += 1) {
+        const settled = settledResults[index];
+        const student = studentChunk[index];
+        if (settled.status === "fulfilled") {
+          results.push(settled.value);
+          continue;
+        }
+
+        errors.push(buildStudentError(student, settled.reason));
       }
     }
 
@@ -231,6 +257,9 @@ export async function POST(request: Request) {
     });
 
     if (results.length > 0) {
+      console.info(
+        `strategy-batch complete: classId=${classKey} assignmentId=${assignmentKey} students=${students.length} results=${results.length} errors=${errors.length} durationMs=${Date.now() - startedAt}`,
+      );
       return NextResponse.json({ results, distribution, errors });
     }
 
@@ -239,6 +268,9 @@ export async function POST(request: Request) {
       error.error === "Strategy generation timed out before the model returned.",
     );
 
+    console.info(
+      `strategy-batch failed: classId=${classKey} assignmentId=${assignmentKey} students=${students.length} results=0 errors=${errors.length} durationMs=${Date.now() - startedAt}`,
+    );
     return NextResponse.json(
       { error: firstError, errors, distribution },
       { status: timedOut ? 504 : 500 },

--- a/app/components/TeacherView.tsx
+++ b/app/components/TeacherView.tsx
@@ -46,7 +46,7 @@ type StrategyBatchResponse = {
   error?: string;
 };
 
-const COHORT_ANALYSIS_CHUNK_SIZE = 1;
+const COHORT_ANALYSIS_CHUNK_SIZE = 4;
 const COHORT_ANALYSIS_MAX_ATTEMPTS = 2;
 
 const collectPublishedMedia = (
@@ -1128,7 +1128,6 @@ export default function TeacherView({ user }: Props) {
                 ? `Analyzing batch ${chunkIndex + 1} of ${studentChunks.length} (${batchStart}-${batchEnd} of ${uncachedStudents.length} uncached students)...`
                 : `Retrying ${pendingStudents.length} student${pendingStudents.length === 1 ? "" : "s"} in batch ${chunkIndex + 1} of ${studentChunks.length}...`,
           });
-
           const res = await fetch("/api/strategy-batch", {
             method: "POST",
             headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary
- run strategy batch requests with bounded server-side concurrency instead of serial student-by-student processing
- increase cohort analysis chunk size in the teacher UI from 1 to 4 students per batch
- add regression coverage proving a batch starts multiple student analyses in parallel

## Why
A 15-student cohort was still timing out after the timeout-handling PR because the system was still effectively serialized end to end. This change reduces total wall-clock time for cohort analysis while preserving the existing timeout and partial-result handling.

## Testing
- npx vitest run __tests__/api/strategy-batch.test.ts
- npm run build
- npx eslint app/api/strategy-batch/route.ts app/components/TeacherView.tsx __tests__/api/strategy-batch.test.ts  # existing TeacherView <img> warnings only