### PR TITLE
Always reanalyze cohort strategies when teacher reruns analysis

### DIFF
--- a/__tests__/api/strategy-batch.test.ts
+++ b/__tests__/api/strategy-batch.test.ts
@@ -38,6 +38,9 @@ vi.mock("@/lib/nosql", () => {
     upsertCachedPlanJson: vi.fn(async (classId: string, assignmentId: string, studentId: string, planJson: string) => {
       cache.set(`${classId}:${assignmentId}:${studentId}`, planJson);
     }),
+    __seedCache: (classId: string, assignmentId: string, studentId: string, planJson: string) => {
+      cache.set(`${classId}:${assignmentId}:${studentId}`, planJson);
+    },
     __resetCache: () => {
       cache.clear();
     },
@@ -45,11 +48,20 @@ vi.mock("@/lib/nosql", () => {
 });
 
 const { POST } = await import("@/app/api/strategy-batch/route");
-const { __resetCache } = (await import("@/lib/nosql")) as unknown as {
+const { __resetCache, __seedCache } = (await import("@/lib/nosql")) as unknown as {
   __resetCache: () => void;
+  __seedCache: (
+    classId: string,
+    assignmentId: string,
+    studentId: string,
+    planJson: string,
+  ) => void;
 };
 
-const buildRequest = (students: Array<Record<string, unknown>>) =>
+const buildRequest = (
+  students: Array<Record<string, unknown>>,
+  options?: { forceRefresh?: boolean },
+) =>
   new Request("http://localhost:3000/api/strategy-batch", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -57,6 +69,7 @@ const buildRequest = (students: Array<Record<string, unknown>>) =>
       classId: "class-1",
       assignmentId: "assignment-1",
       students,
+      ...(options?.forceRefresh ? { forceRefresh: true } : {}),
     }),
   });
 
@@ -147,5 +160,71 @@ describe("POST /api/strategy-batch", () => {
         error: "Strategy generation timed out before the model returned.",
       },
     ]);
+  });
+
+  it("bypasses cached plans when forceRefresh is true", async () => {
+    __seedCache(
+      "class-1",
+      "assignment-1",
+      "student-1",
+      JSON.stringify({
+        name: "Cached plan",
+        strategy: "analogy",
+        relevance: {
+          "cognitive conflict": 10,
+          analogy: 90,
+          "experience bridging": 20,
+          "engaged critiquing": 30,
+        },
+        overallRecommendation: "Cached recommendation.",
+        recommendationReason: "Cached reason.",
+        summary: "Cached summary.",
+        tldr: "Cached tl dr.",
+        rationale: "Cached rationale.",
+        tactics: ["Cached tactic."],
+        cadence: "Cached cadence",
+        checks: ["Cached check."],
+      }),
+    );
+    createCompletion.mockResolvedValueOnce({
+      choices: [
+        {
+          message: {
+            content: JSON.stringify({
+              name: "Fresh plan",
+              strategy: "experience bridging",
+              relevance: {
+                "cognitive conflict": 10,
+                analogy: 15,
+                "experience bridging": 90,
+                "engaged critiquing": 20,
+              },
+              overallRecommendation: "Fresh recommendation.",
+              recommendationReason: "Fresh reason.",
+              summary: "Fresh summary.",
+              tldr: "Fresh tl dr.",
+              rationale: "Fresh rationale.",
+              tactics: ["Fresh tactic."],
+              cadence: "Fresh cadence",
+              checks: ["Fresh check."],
+            }),
+          },
+        },
+      ],
+    });
+
+    const res = await POST(buildRequest([
+      { id: "student-1", name: "Ava", answers: { q1: "A", q2: "B" } },
+    ], { forceRefresh: true }));
+
+    expect(res.status).toBe(200);
+    expect(createCompletion).toHaveBeenCalledTimes(1);
+    const data = await res.json();
+    expect(data.results[0]).toMatchObject({
+      id: "student-1",
+      plan: {
+        strategy: "experience bridging",
+      },
+    });
   });
 });

--- a/app/api/strategy-batch/route.ts
+++ b/app/api/strategy-batch/route.ts
@@ -130,23 +130,27 @@ const generatePlanForStudent = async ({
   classKey,
   assignmentKey,
   student,
+  forceRefresh,
 }: {
   client: OpenAI;
   model: string;
   classKey: string;
   assignmentKey: string;
   student: Student;
+  forceRefresh?: boolean;
 }): Promise<StudentStrategyResult> => {
-  const cachedPlanJson = await getCachedPlanJson(
-    classKey,
-    assignmentKey,
-    student.id,
-  );
-  if (cachedPlanJson) {
-    const cachedPlan = JSON.parse(cachedPlanJson) as Plan;
-    cachedPlan.strategy = normalizeStrategy(cachedPlan.strategy);
-    const plan = ensurePlanFields(cachedPlan);
-    return { id: student.id, name: student.name, plan };
+  if (!forceRefresh) {
+    const cachedPlanJson = await getCachedPlanJson(
+      classKey,
+      assignmentKey,
+      student.id,
+    );
+    if (cachedPlanJson) {
+      const cachedPlan = JSON.parse(cachedPlanJson) as Plan;
+      cachedPlan.strategy = normalizeStrategy(cachedPlan.strategy);
+      const plan = ensurePlanFields(cachedPlan);
+      return { id: student.id, name: student.name, plan };
+    }
   }
 
   const prompt = buildPrompt(student);
@@ -191,10 +195,12 @@ export async function POST(request: Request) {
       students = [],
       classId,
       assignmentId,
+      forceRefresh = false,
     } = (await request.json()) as {
       students?: Student[];
       classId?: string;
       assignmentId?: string;
+      forceRefresh?: boolean;
     };
     const classKey = classId?.trim();
     const assignmentKey = assignmentId?.trim();
@@ -217,6 +223,7 @@ export async function POST(request: Request) {
           classKey,
           assignmentKey,
           student,
+          forceRefresh,
         });
         results.push(result);
       } catch (error) {

--- a/app/components/TeacherView.tsx
+++ b/app/components/TeacherView.tsx
@@ -1058,7 +1058,7 @@ export default function TeacherView({ user }: Props) {
     setSelectedForPublish(new Set());
     setCohortResults([]);
     setCohortDistribution({});
-    setCohortProgress({ processed: 0, total: studentAnswers.length, currentName: "Loading cache..." });
+    setCohortProgress({ processed: 0, total: studentAnswers.length, currentName: "Starting cohort analysis..." });
 
     try {
       const studentsForApi = studentAnswers.map((sa) => ({
@@ -1068,45 +1068,9 @@ export default function TeacherView({ user }: Props) {
         answers: sa.answers,
       }));
 
-      const cacheUrl = `/api/strategy-cache?classId=${encodeURIComponent(classId)}&assignmentId=${encodeURIComponent(assignmentId)}`;
-      const cacheRes = await fetch(cacheUrl);
-      let cacheData: { results?: Array<{ studentId?: string; plan?: unknown }> } = { results: [] };
-      if (cacheRes.ok) {
-        cacheData = await cacheRes.json();
-      }
-
-      const cachedMap = new Map<string, Plan>();
-      for (const entry of cacheData.results ?? []) {
-        if (entry.studentId && entry.plan) {
-          cachedMap.set(entry.studentId, entry.plan as Plan);
-        }
-      }
-
       const resultsMap = new Map<string, StudentStrategyResult>();
-      for (const student of studentsForApi) {
-        const cached = cachedMap.get(student.id);
-        if (!cached) continue;
-        resultsMap.set(student.id, { id: student.id, name: student.name, plan: cached });
-      }
-
-      const initialResults = studentsForApi
-        .filter((student) => resultsMap.has(student.id))
-        .map((student) => resultsMap.get(student.id) as StudentStrategyResult);
-      setCohortResults(initialResults);
-      setCohortProgress({
-        processed: initialResults.length,
-        total: studentsForApi.length,
-        currentName:
-          initialResults.length > 0
-            ? `Loaded ${initialResults.length} cached student${initialResults.length === 1 ? "" : "s"}.`
-            : "Starting cohort analysis...",
-      });
-
-      const uncachedStudents = studentsForApi.filter(
-        (student) => !cachedMap.has(student.id),
-      );
       const studentChunks = chunkItems(
-        uncachedStudents,
+        studentsForApi,
         COHORT_ANALYSIS_CHUNK_SIZE,
       );
 
@@ -1117,7 +1081,7 @@ export default function TeacherView({ user }: Props) {
           const batchStart = chunkIndex * COHORT_ANALYSIS_CHUNK_SIZE + 1;
           const batchEnd = Math.min(
             batchStart + pendingStudents.length - 1,
-            uncachedStudents.length,
+            studentsForApi.length,
           );
 
           setCohortProgress({
@@ -1125,7 +1089,7 @@ export default function TeacherView({ user }: Props) {
             total: studentsForApi.length,
             currentName:
               attempt === 1
-                ? `Analyzing batch ${chunkIndex + 1} of ${studentChunks.length} (${batchStart}-${batchEnd} of ${uncachedStudents.length} uncached students)...`
+                ? `Analyzing batch ${chunkIndex + 1} of ${studentChunks.length} (${batchStart}-${batchEnd} of ${studentsForApi.length} students)...`
                 : `Retrying ${pendingStudents.length} student${pendingStudents.length === 1 ? "" : "s"} in batch ${chunkIndex + 1} of ${studentChunks.length}...`,
           });
 
@@ -1136,6 +1100,7 @@ export default function TeacherView({ user }: Props) {
               students: pendingStudents,
               classId,
               assignmentId,
+              forceRefresh: true,
             }),
           });
           const data = await parseJsonResponse<StrategyBatchResponse>(res);


### PR DESCRIPTION
## Summary
- stop preloading cached cohort strategy plans in the teacher analyze flow
- send `forceRefresh: true` when the teacher runs cohort analysis so previously analyzed students are regenerated
- keep overwriting the stored cache with the fresh results and add regression coverage for force-refresh behavior

## Why
Teachers expect clicking Analyze again to recompute the cohort using the latest student answers, not silently reuse old cached strategy plans. This change makes reruns deterministic: every click triggers a fresh cohort analysis.

## Testing
- npx vitest run __tests__/api/strategy-batch.test.ts
- npm run build
- npx eslint app/api/strategy-batch/route.ts app/components/TeacherView.tsx __tests__/api/strategy-batch.test.ts  # existing TeacherView <img> warnings only