### PR TITLE
Add async cohort analysis job queue

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,7 @@ ENGAGE_AWS_REGION=us-east-2
 ENGAGE_AWS_ACCESS_KEY_ID=your_aws_access_key_id
 ENGAGE_AWS_SECRET_ACCESS_KEY=your_aws_secret_access_key
 ENGAGE_S3_BUCKET=genius-engage-agent-media
+COHORT_ANALYSIS_QUEUE_URL=
 
 # Optional — script tuning
 FEEDBACK_TICKET_CONCURRENCY=6

--- a/.github/workflows/deploy-cohort-analysis-worker.yml
+++ b/.github/workflows/deploy-cohort-analysis-worker.yml
@@ -1,0 +1,54 @@
+name: Deploy Cohort Analysis Worker
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/deploy-cohort-analysis-worker.yml"
+      - "data/lesson*.json"
+      - "scripts/deploy-cohort-analysis-worker.sh"
+      - "scripts/update-cohort-analysis-worker.sh"
+      - "workers/cohort-analysis-worker/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: deploy-cohort-analysis-worker-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      AWS_REGION: ${{ vars.ENGAGE_AWS_REGION || 'us-east-2' }}
+      AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+      COHORT_ANALYSIS_WORKER_FUNCTION_NAME: ${{ vars.COHORT_ANALYSIS_WORKER_FUNCTION_NAME }}
+    steps:
+      - name: Validate deploy configuration
+        run: |
+          if [[ -z "$AWS_ROLE_TO_ASSUME" ]]; then
+            echo "::error::Set the AWS_ROLE_TO_ASSUME GitHub secret before running this workflow."
+            exit 1
+          fi
+          if [[ -z "$COHORT_ANALYSIS_WORKER_FUNCTION_NAME" ]]; then
+            echo "::error::Set the COHORT_ANALYSIS_WORKER_FUNCTION_NAME GitHub variable before running this workflow."
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
+
+      - name: Deploy Lambda code
+        run: ./scripts/update-cohort-analysis-worker.sh

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ FEEDBACK_TICKET_CONCURRENCY=6
 
 Set `ENGAGE_AWS_REGION` to the actual region where your DynamoDB table and S3 bucket live. For the current shared AWS setup, that is `us-east-2`.
 
+If you want the local app to push uncached cohort analysis work to SQS, set `COHORT_ANALYSIS_QUEUE_URL` in `.env` (or `.env.local`) before starting `npm run dev`. If that variable is missing, the teacher flow falls back to inline cohort analysis on the app server.
+
 ### 3. Run the development server
 
 ```bash
@@ -200,6 +202,13 @@ Package the worker with:
 ./scripts/deploy-cohort-analysis-worker.sh
 ```
 
+Deploy the packaged worker to Lambda with:
+
+```bash
+COHORT_ANALYSIS_WORKER_FUNCTION_NAME=genius-engage-cohort-analysis-worker \
+./scripts/update-cohort-analysis-worker.sh
+```
+
 The resulting zip includes the worker code, production dependencies, and the
 lesson JSON files from `data/`.
 
@@ -213,3 +222,26 @@ Recommended worker configuration:
   CloudWatch Logs permissions
 - An SQS event source mapping from the queue to the worker Lambda
 - Queue visibility timeout longer than the worker runtime budget
+
+### Automated Lambda deploy
+
+The repository includes `.github/workflows/deploy-cohort-analysis-worker.yml`.
+It deploys the worker automatically on pushes to `main` when any of these
+change:
+
+- `workers/cohort-analysis-worker/**`
+- `data/lesson*.json`
+- `scripts/deploy-cohort-analysis-worker.sh`
+- `scripts/update-cohort-analysis-worker.sh`
+
+It also supports manual `workflow_dispatch` runs for branch testing.
+
+Configure these GitHub repository settings before using it:
+
+- Secret: `AWS_ROLE_TO_ASSUME`
+- Variable: `COHORT_ANALYSIS_WORKER_FUNCTION_NAME`
+- Variable: `ENGAGE_AWS_REGION` (optional; defaults to `us-east-2`)
+
+The assumed AWS role needs permission to update Lambda function code for the
+worker. The workflow updates code only; queue mappings, triggers, and Lambda
+environment variables remain managed in AWS.

--- a/__tests__/api/strategy-batch.test.ts
+++ b/__tests__/api/strategy-batch.test.ts
@@ -49,7 +49,10 @@ const { __resetCache } = (await import("@/lib/nosql")) as unknown as {
   __resetCache: () => void;
 };
 
-const buildRequest = (students: Array<Record<string, unknown>>) =>
+const buildRequest = (
+  students: Array<Record<string, unknown>>,
+  options?: { forceRefresh?: boolean },
+) =>
   new Request("http://localhost:3000/api/strategy-batch", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -57,6 +60,7 @@ const buildRequest = (students: Array<Record<string, unknown>>) =>
       classId: "class-1",
       assignmentId: "assignment-1",
       lessonNumber: 1,
+      forceRefresh: options?.forceRefresh,
       students,
     }),
   });
@@ -215,5 +219,50 @@ describe("POST /api/strategy-batch", () => {
     expect(userPrompt).toContain(
       "If nothing looks damaged after the collision, the force must have been weak.",
     );
+  });
+
+  it("bypasses cached plans when forceRefresh is true", async () => {
+    createCompletion.mockResolvedValueOnce(buildCompletion("analogy"));
+
+    const firstRes = await POST(buildRequest([
+      {
+        id: "student-1",
+        name: "Ava",
+        answers: {
+          L1_Q1: "D",
+          L1_Q1_confidence: "B",
+        },
+      },
+    ]));
+
+    expect(firstRes.status).toBe(200);
+    expect(createCompletion).toHaveBeenCalledTimes(1);
+
+    createCompletion.mockReset();
+    createCompletion.mockResolvedValueOnce(buildCompletion("cognitive conflict"));
+
+    const secondRes = await POST(buildRequest([
+      {
+        id: "student-1",
+        name: "Ava",
+        answers: {
+          L1_Q1: "D",
+          L1_Q1_confidence: "B",
+        },
+      },
+    ], { forceRefresh: true }));
+
+    expect(secondRes.status).toBe(200);
+    expect(createCompletion).toHaveBeenCalledTimes(1);
+
+    const data = await secondRes.json();
+    expect(data.results).toMatchObject([
+      {
+        id: "student-1",
+        plan: {
+          strategy: "cognitive conflict",
+        },
+      },
+    ]);
   });
 });

--- a/__tests__/api/strategy-job.test.ts
+++ b/__tests__/api/strategy-job.test.ts
@@ -1,0 +1,201 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  createCohortJob,
+  enqueueCohortJobStudents,
+  getCohortJob,
+  isCohortAnalysisQueueConfigured,
+  setCohortJobStatus,
+  randomUUID,
+} = vi.hoisted(() => ({
+  createCohortJob: vi.fn(),
+  enqueueCohortJobStudents: vi.fn(),
+  getCohortJob: vi.fn(),
+  isCohortAnalysisQueueConfigured: vi.fn(),
+  setCohortJobStatus: vi.fn(),
+  randomUUID: vi.fn(() => "job-123"),
+}));
+
+vi.mock("node:crypto", () => ({
+  default: {
+    randomUUID,
+  },
+}));
+
+vi.mock("@/lib/cohort-analysis-queue", () => ({
+  enqueueCohortJobStudents,
+  isCohortAnalysisQueueConfigured,
+}));
+
+vi.mock("@/lib/nosql", () => ({
+  createCohortJob,
+  getCohortJob,
+  setCohortJobStatus,
+}));
+
+const { POST } = await import("@/app/api/strategy-job/route");
+const { GET } = await import("@/app/api/strategy-job/[jobId]/route");
+
+beforeEach(() => {
+  createCohortJob.mockReset();
+  enqueueCohortJobStudents.mockReset();
+  getCohortJob.mockReset();
+  isCohortAnalysisQueueConfigured.mockReset();
+  setCohortJobStatus.mockReset();
+  randomUUID.mockClear();
+});
+
+describe("POST /api/strategy-job", () => {
+  it("creates a cohort job and enqueues uncached students", async () => {
+    isCohortAnalysisQueueConfigured.mockReturnValue(true);
+    createCohortJob.mockResolvedValue(undefined);
+    enqueueCohortJobStudents.mockResolvedValue(undefined);
+
+    const res = await POST(
+      new Request("http://localhost:3000/api/strategy-job", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          classId: "class-1",
+          assignmentId: "assignment-1",
+          students: [
+            { id: "student-1", name: "Ava", assignment: "Lesson 1", answers: { q1: "A" } },
+            { id: "student-2", name: "Jon", assignment: "Lesson 1", answers: { q1: "B" } },
+          ],
+        }),
+      }),
+    );
+
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data).toEqual({
+      jobId: "job-123",
+      queuedStudents: 2,
+      totalStudents: 2,
+      status: "queued",
+    });
+    expect(createCohortJob).toHaveBeenCalledWith(
+      "job-123",
+      "class-1",
+      "assignment-1",
+      2,
+    );
+    expect(enqueueCohortJobStudents).toHaveBeenCalledWith({
+      jobId: "job-123",
+      classId: "class-1",
+      assignmentId: "assignment-1",
+      totalStudents: 2,
+      students: [
+        { id: "student-1", name: "Ava", assignment: "Lesson 1", answers: { q1: "A" } },
+        { id: "student-2", name: "Jon", assignment: "Lesson 1", answers: { q1: "B" } },
+      ],
+    });
+  });
+
+  it("returns 501 when the queue is not configured", async () => {
+    isCohortAnalysisQueueConfigured.mockReturnValue(false);
+
+    const res = await POST(
+      new Request("http://localhost:3000/api/strategy-job", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          classId: "class-1",
+          assignmentId: "assignment-1",
+          students: [{ id: "student-1", name: "Ava", answers: { q1: "A" } }],
+        }),
+      }),
+    );
+
+    expect(res.status).toBe(501);
+    const data = await res.json();
+    expect(data.error).toBe(
+      "Cohort analysis queue is not configured on this environment.",
+    );
+  });
+});
+
+describe("GET /api/strategy-job/[jobId]", () => {
+  it("returns job progress, parsed student results, and failures", async () => {
+    getCohortJob.mockResolvedValue({
+      job: {
+        job_id: "job-123",
+        class_id: "class-1",
+        assignment_id: "assignment-1",
+        total_students: 2,
+        processed_students: 2,
+        completed_students: 1,
+        failed_students: 1,
+        status: "completed_with_errors",
+        error_message: undefined,
+        created_at: "2026-03-25T00:00:00.000Z",
+        updated_at: "2026-03-25T00:01:00.000Z",
+      },
+      students: [
+        {
+          job_id: "job-123",
+          class_id: "class-1",
+          assignment_id: "assignment-1",
+          student_id: "student-1",
+          student_name: "Ava",
+          status: "completed",
+          source: "model",
+          plan_json: JSON.stringify({
+            strategy: "Analogy",
+            summary: "Use analogy.",
+          }),
+          updated_at: "2026-03-25T00:00:30.000Z",
+        },
+        {
+          job_id: "job-123",
+          class_id: "class-1",
+          assignment_id: "assignment-1",
+          student_id: "student-2",
+          student_name: "Jon",
+          status: "failed",
+          error: "Request timed out.",
+          updated_at: "2026-03-25T00:00:45.000Z",
+        },
+      ],
+    });
+
+    const res = await GET(
+      new Request("http://localhost:3000/api/strategy-job/job-123"),
+      { params: Promise.resolve({ jobId: "job-123" }) },
+    );
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.job).toEqual({
+      jobId: "job-123",
+      classId: "class-1",
+      assignmentId: "assignment-1",
+      totalStudents: 2,
+      processedStudents: 2,
+      completedStudents: 1,
+      failedStudents: 1,
+      status: "completed_with_errors",
+      errorMessage: null,
+      createdAt: "2026-03-25T00:00:00.000Z",
+      updatedAt: "2026-03-25T00:01:00.000Z",
+    });
+    expect(data.results).toEqual([
+      {
+        id: "student-1",
+        name: "Ava",
+        plan: {
+          strategy: "analogy",
+          summary: "Use analogy.",
+        },
+      },
+    ]);
+    expect(data.errors).toEqual([
+      {
+        id: "student-2",
+        name: "Jon",
+        error: "Request timed out.",
+      },
+    ]);
+    expect(data.distribution).toEqual({ analogy: 1 });
+  });
+});

--- a/__tests__/api/strategy-job.test.ts
+++ b/__tests__/api/strategy-job.test.ts
@@ -91,9 +91,45 @@ describe("POST /api/strategy-job", () => {
       assignmentId: "assignment-1",
       lessonNumber: 2,
       totalStudents: 2,
+      forceRefresh: false,
       students: [
         { id: "student-1", name: "Ava", assignment: "Lesson 1", answers: { q1: "A" } },
         { id: "student-2", name: "Jon", assignment: "Lesson 1", answers: { q1: "B" } },
+      ],
+    });
+  });
+
+  it("passes forceRefresh through to the queue payload", async () => {
+    isCohortAnalysisQueueConfigured.mockReturnValue(true);
+    createCohortJob.mockResolvedValue(undefined);
+    enqueueCohortJobStudents.mockResolvedValue(undefined);
+
+    const res = await POST(
+      new Request("http://localhost:3000/api/strategy-job", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          classId: "class-1",
+          assignmentId: "assignment-1",
+          lessonNumber: 2,
+          forceRefresh: true,
+          students: [
+            { id: "student-1", name: "Ava", assignment: "Lesson 1", answers: { q1: "A" } },
+          ],
+        }),
+      }),
+    );
+
+    expect(res.status).toBe(201);
+    expect(enqueueCohortJobStudents).toHaveBeenCalledWith({
+      jobId: "job-123",
+      classId: "class-1",
+      assignmentId: "assignment-1",
+      lessonNumber: 2,
+      totalStudents: 1,
+      forceRefresh: true,
+      students: [
+        { id: "student-1", name: "Ava", assignment: "Lesson 1", answers: { q1: "A" } },
       ],
     });
   });

--- a/__tests__/api/strategy-job.test.ts
+++ b/__tests__/api/strategy-job.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const {
   createCohortJob,
   enqueueCohortJobStudents,
+  getCohortAnalysisQueueConfigIssues,
   getCohortJob,
   isCohortAnalysisQueueConfigured,
   setCohortJobStatus,
@@ -10,6 +11,7 @@ const {
 } = vi.hoisted(() => ({
   createCohortJob: vi.fn(),
   enqueueCohortJobStudents: vi.fn(),
+  getCohortAnalysisQueueConfigIssues: vi.fn(),
   getCohortJob: vi.fn(),
   isCohortAnalysisQueueConfigured: vi.fn(),
   setCohortJobStatus: vi.fn(),
@@ -24,6 +26,7 @@ vi.mock("node:crypto", () => ({
 
 vi.mock("@/lib/cohort-analysis-queue", () => ({
   enqueueCohortJobStudents,
+  getCohortAnalysisQueueConfigIssues,
   isCohortAnalysisQueueConfigured,
 }));
 
@@ -39,6 +42,7 @@ const { GET } = await import("@/app/api/strategy-job/[jobId]/route");
 beforeEach(() => {
   createCohortJob.mockReset();
   enqueueCohortJobStudents.mockReset();
+  getCohortAnalysisQueueConfigIssues.mockReset();
   getCohortJob.mockReset();
   isCohortAnalysisQueueConfigured.mockReset();
   setCohortJobStatus.mockReset();
@@ -96,6 +100,9 @@ describe("POST /api/strategy-job", () => {
 
   it("returns 501 when the queue is not configured", async () => {
     isCohortAnalysisQueueConfigured.mockReturnValue(false);
+    getCohortAnalysisQueueConfigIssues.mockReturnValue([
+      "COHORT_ANALYSIS_QUEUE_URL",
+    ]);
 
     const res = await POST(
       new Request("http://localhost:3000/api/strategy-job", {
@@ -112,9 +119,10 @@ describe("POST /api/strategy-job", () => {
 
     expect(res.status).toBe(501);
     const data = await res.json();
-    expect(data.error).toBe(
-      "Cohort analysis queue is not configured on this environment.",
-    );
+    expect(data).toEqual({
+      error: "Cohort analysis queue is not configured on this environment.",
+      missingEnv: ["COHORT_ANALYSIS_QUEUE_URL"],
+    });
   });
 
   it("returns 400 when lessonNumber is missing", async () => {

--- a/amplify.yml
+++ b/amplify.yml
@@ -14,6 +14,7 @@ frontend:
         - echo "ENGAGE_AWS_REGION=$ENGAGE_AWS_REGION" >> .env.production
         - echo "ENGAGE_AWS_ACCESS_KEY_ID=$ENGAGE_AWS_ACCESS_KEY_ID" >> .env.production
         - echo "ENGAGE_AWS_SECRET_ACCESS_KEY=$ENGAGE_AWS_SECRET_ACCESS_KEY" >> .env.production
+        - echo "COHORT_ANALYSIS_QUEUE_URL=$COHORT_ANALYSIS_QUEUE_URL" >> .env.production
         - npm run build
   artifacts:
     baseDirectory: .next

--- a/app/api/strategy-batch/route.ts
+++ b/app/api/strategy-batch/route.ts
@@ -158,6 +158,7 @@ const generatePlanForStudent = async ({
   model,
   classKey,
   assignmentKey,
+  forceRefresh,
   student,
   lessonContext,
   quizEvidence,
@@ -166,24 +167,27 @@ const generatePlanForStudent = async ({
   model: string;
   classKey: string;
   assignmentKey: string;
+  forceRefresh: boolean;
   student: Student;
   lessonContext: LessonGenerationContext | null;
   quizEvidence: ResolvedQuizEvidence[];
 }): Promise<StudentStrategyResult> => {
-  const cachedPlanJson = await getCachedPlanJson(
-    classKey,
-    assignmentKey,
-    student.id,
-  );
-  if (cachedPlanJson) {
-    const cachedPlan = deserializeCachedPlan<Plan>(cachedPlanJson, {
-      lessonNumber: lessonContext?.lessonNumber,
-      requireVersionMatch: lessonContext !== null,
-    });
-    if (cachedPlan) {
-      cachedPlan.strategy = normalizeStrategy(cachedPlan.strategy);
-      const plan = ensurePlanFields(cachedPlan);
-      return { id: student.id, name: student.name, plan };
+  if (!forceRefresh) {
+    const cachedPlanJson = await getCachedPlanJson(
+      classKey,
+      assignmentKey,
+      student.id,
+    );
+    if (cachedPlanJson) {
+      const cachedPlan = deserializeCachedPlan<Plan>(cachedPlanJson, {
+        lessonNumber: lessonContext?.lessonNumber,
+        requireVersionMatch: lessonContext !== null,
+      });
+      if (cachedPlan) {
+        cachedPlan.strategy = normalizeStrategy(cachedPlan.strategy);
+        const plan = ensurePlanFields(cachedPlan);
+        return { id: student.id, name: student.name, plan };
+      }
     }
   }
 
@@ -231,11 +235,13 @@ export async function POST(request: Request) {
       classId,
       assignmentId,
       lessonNumber,
+      forceRefresh,
     } = (await request.json()) as {
       students?: Student[];
       classId?: string;
       assignmentId?: string;
       lessonNumber?: number;
+      forceRefresh?: boolean;
     };
     const classKey = classId?.trim();
     const assignmentKey = assignmentId?.trim();
@@ -258,6 +264,7 @@ export async function POST(request: Request) {
     }
 
     const model = process.env.OPENAI_MODEL ?? "gpt-5-nano";
+    const shouldForceRefresh = forceRefresh === true;
     const results: StudentStrategyResult[] = [];
     const errors: StudentStrategyError[] = [];
 
@@ -270,6 +277,7 @@ export async function POST(request: Request) {
             model,
             classKey,
             assignmentKey,
+            forceRefresh: shouldForceRefresh,
             student,
             lessonContext,
             quizEvidence:

--- a/app/api/strategy-job/[jobId]/route.ts
+++ b/app/api/strategy-job/[jobId]/route.ts
@@ -1,0 +1,90 @@
+import { NextResponse } from "next/server";
+
+import { getCohortJob } from "@/lib/nosql";
+
+type Plan = {
+  strategy?: string;
+  [key: string]: unknown;
+};
+
+const normalizeStrategy = (strategy: string) => strategy.trim().toLowerCase();
+
+const parsePlan = (value: string | undefined): Plan | null => {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(value) as Plan;
+    if (typeof parsed.strategy === "string") {
+      parsed.strategy = normalizeStrategy(parsed.strategy);
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+};
+
+export const runtime = "nodejs";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ jobId: string }> },
+) {
+  const { jobId } = await params;
+
+  const data = await getCohortJob(jobId);
+  if (!data.job) {
+    return NextResponse.json({ error: "Cohort analysis job not found." }, { status: 404 });
+  }
+
+  const results = data.students
+    .map((student) => {
+      const plan = parsePlan(student.plan_json);
+      if (student.status !== "completed" || !plan) {
+        return null;
+      }
+      return {
+        id: student.student_id,
+        name: student.student_name,
+        plan,
+      };
+    })
+    .filter((result): result is NonNullable<typeof result> => Boolean(result));
+
+  const errors = data.students
+    .filter((student) => student.status === "failed")
+    .map((student) => ({
+      id: student.student_id,
+      name: student.student_name,
+      error: student.error ?? "Failed to analyze student.",
+    }));
+
+  const distribution: Record<string, number> = {};
+  results.forEach((result) => {
+    if (!result.plan.strategy || typeof result.plan.strategy !== "string") {
+      return;
+    }
+    const key = normalizeStrategy(result.plan.strategy);
+    distribution[key] = (distribution[key] ?? 0) + 1;
+  });
+
+  return NextResponse.json({
+    job: {
+      jobId: data.job.job_id,
+      classId: data.job.class_id,
+      assignmentId: data.job.assignment_id,
+      totalStudents: data.job.total_students,
+      processedStudents: data.job.processed_students,
+      completedStudents: data.job.completed_students,
+      failedStudents: data.job.failed_students,
+      status: data.job.status,
+      errorMessage: data.job.error_message ?? null,
+      createdAt: data.job.created_at,
+      updatedAt: data.job.updated_at,
+    },
+    results,
+    errors,
+    distribution,
+  });
+}

--- a/app/api/strategy-job/route.ts
+++ b/app/api/strategy-job/route.ts
@@ -36,11 +36,13 @@ export async function POST(request: Request) {
       classId,
       assignmentId,
       lessonNumber,
+      forceRefresh,
       students = [],
     } = (await request.json()) as {
       classId?: string;
       assignmentId?: string;
       lessonNumber?: number;
+      forceRefresh?: boolean;
       students?: Student[];
     };
 
@@ -63,6 +65,7 @@ export async function POST(request: Request) {
     const normalizedStudents = (students ?? []).filter(
       (student) => student?.id && student?.name,
     );
+    const shouldForceRefresh = forceRefresh === true;
     if (normalizedStudents.length === 0) {
       return NextResponse.json(
         { error: "At least one student is required." },
@@ -85,6 +88,7 @@ export async function POST(request: Request) {
         assignmentId: assignmentKey,
         lessonNumber: normalizedLessonNumber,
         totalStudents: normalizedStudents.length,
+        forceRefresh: shouldForceRefresh,
         students: normalizedStudents,
       });
     } catch (error) {

--- a/app/api/strategy-job/route.ts
+++ b/app/api/strategy-job/route.ts
@@ -1,0 +1,99 @@
+import crypto from "node:crypto";
+
+import { NextResponse } from "next/server";
+
+import {
+  enqueueCohortJobStudents,
+  isCohortAnalysisQueueConfigured,
+} from "@/lib/cohort-analysis-queue";
+import { createCohortJob, setCohortJobStatus } from "@/lib/nosql";
+
+type Student = {
+  id: string;
+  name: string;
+  assignment?: string;
+  answers: Record<string, string | undefined>;
+};
+
+export const runtime = "nodejs";
+
+export async function POST(request: Request) {
+  try {
+    if (!isCohortAnalysisQueueConfigured()) {
+      return NextResponse.json(
+        {
+          error:
+            "Cohort analysis queue is not configured on this environment.",
+        },
+        { status: 501 },
+      );
+    }
+
+    const { classId, assignmentId, students = [] } = (await request.json()) as {
+      classId?: string;
+      assignmentId?: string;
+      students?: Student[];
+    };
+
+    const classKey = classId?.trim();
+    const assignmentKey = assignmentId?.trim();
+
+    if (!classKey || !assignmentKey) {
+      return NextResponse.json(
+        { error: "classId and assignmentId are required." },
+        { status: 400 },
+      );
+    }
+
+    const normalizedStudents = (students ?? []).filter(
+      (student) => student?.id && student?.name,
+    );
+    if (normalizedStudents.length === 0) {
+      return NextResponse.json(
+        { error: "At least one student is required." },
+        { status: 400 },
+      );
+    }
+
+    const jobId = crypto.randomUUID();
+    await createCohortJob(
+      jobId,
+      classKey,
+      assignmentKey,
+      normalizedStudents.length,
+    );
+
+    try {
+      await enqueueCohortJobStudents({
+        jobId,
+        classId: classKey,
+        assignmentId: assignmentKey,
+        totalStudents: normalizedStudents.length,
+        students: normalizedStudents,
+      });
+    } catch (error) {
+      await setCohortJobStatus(
+        jobId,
+        "failed_to_queue",
+        error instanceof Error ? error.message : "Failed to queue cohort analysis.",
+      );
+      throw error;
+    }
+
+    return NextResponse.json(
+      {
+        jobId,
+        queuedStudents: normalizedStudents.length,
+        totalStudents: normalizedStudents.length,
+        status: "queued",
+      },
+      { status: 201 },
+    );
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : "Failed to start cohort analysis.";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/api/strategy-job/route.ts
+++ b/app/api/strategy-job/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from "next/server";
 
 import {
   enqueueCohortJobStudents,
+  getCohortAnalysisQueueConfigIssues,
   isCohortAnalysisQueueConfigured,
 } from "@/lib/cohort-analysis-queue";
 import { createCohortJob, setCohortJobStatus } from "@/lib/nosql";
@@ -20,10 +21,12 @@ export const runtime = "nodejs";
 export async function POST(request: Request) {
   try {
     if (!isCohortAnalysisQueueConfigured()) {
+      const missingEnv = getCohortAnalysisQueueConfigIssues();
       return NextResponse.json(
         {
           error:
             "Cohort analysis queue is not configured on this environment.",
+          missingEnv,
         },
         { status: 501 },
       );

--- a/app/components/TeacherView.tsx
+++ b/app/components/TeacherView.tsx
@@ -51,6 +51,7 @@ type StrategyJobStartResponse = {
   queuedStudents?: number;
   totalStudents?: number;
   status?: "queued";
+  missingEnv?: string[];
   error?: string;
 };
 
@@ -1287,6 +1288,17 @@ export default function TeacherView({ user }: Props) {
         const startData = await parseJsonResponse<StrategyJobStartResponse>(startRes);
 
         if (startRes.status === 501) {
+          const missingEnv = (startData?.missingEnv ?? [])
+            .filter((name) => typeof name === "string" && name.length > 0);
+          cohortWarning =
+            missingEnv.length > 0
+              ? `Cohort analysis queue is not configured on this environment (${missingEnv.join(", ")}). Running inline analysis instead.`
+              : `${startData?.error ?? "Cohort analysis queue is not configured on this environment."} Running inline analysis instead.`;
+          setCohortProgress({
+            processed: initialResults.length,
+            total: studentsForApi.length,
+            currentName: "Queue not configured here; analyzing inline instead...",
+          });
           await runSynchronousCohortAnalysis({
             lessonNumber,
             studentsForApi,

--- a/app/components/TeacherView.tsx
+++ b/app/components/TeacherView.tsx
@@ -46,8 +46,39 @@ type StrategyBatchResponse = {
   error?: string;
 };
 
+type StrategyJobStartResponse = {
+  jobId?: string;
+  queuedStudents?: number;
+  totalStudents?: number;
+  status?: "queued";
+  error?: string;
+};
+
+type StrategyJobStatusResponse = {
+  job?: {
+    jobId?: string;
+    classId?: string;
+    assignmentId?: string;
+    totalStudents?: number;
+    processedStudents?: number;
+    completedStudents?: number;
+    failedStudents?: number;
+    status?: "queued" | "running" | "completed" | "completed_with_errors" | "failed_to_queue";
+    errorMessage?: string | null;
+    createdAt?: string;
+    updatedAt?: string;
+  };
+  results?: StudentStrategyResult[];
+  errors?: Array<{ id?: string; name?: string; error?: string }>;
+  distribution?: Record<string, number>;
+  error?: string;
+};
+
+type StrategyJobStatus = NonNullable<StrategyJobStatusResponse["job"]>["status"];
+
 const COHORT_ANALYSIS_CHUNK_SIZE = 4;
 const COHORT_ANALYSIS_MAX_ATTEMPTS = 2;
+const COHORT_ANALYSIS_JOB_POLL_MS = 1500;
 
 const collectPublishedMedia = (
   items: PublishedContentPayloadItem[] | undefined,
@@ -209,6 +240,13 @@ const formatStrategyBatchError = (
 
   return `Cohort analysis failed (HTTP ${status}).`;
 };
+
+const isTerminalCohortJobStatus = (
+  status: StrategyJobStatus | undefined,
+) =>
+  status === "completed" ||
+  status === "completed_with_errors" ||
+  status === "failed_to_queue";
 
 const chunkItems = <T,>(items: T[], size: number) => {
   const chunks: T[][] = [];
@@ -1041,6 +1079,115 @@ export default function TeacherView({ user }: Props) {
     return () => window.removeEventListener("beforeunload", handleBeforeUnload);
   }, [loadingCohort]);
 
+  const runSynchronousCohortAnalysis = async ({
+    studentsForApi,
+    uncachedStudents,
+    resultsMap,
+  }: {
+    studentsForApi: Array<{
+      id: string;
+      name: string;
+      assignment?: string;
+      answers: Record<string, string | undefined>;
+    }>;
+    uncachedStudents: Array<{
+      id: string;
+      name: string;
+      assignment?: string;
+      answers: Record<string, string | undefined>;
+    }>;
+    resultsMap: Map<string, StudentStrategyResult>;
+  }) => {
+    const studentChunks = chunkItems(
+      uncachedStudents,
+      COHORT_ANALYSIS_CHUNK_SIZE,
+    );
+
+    for (let chunkIndex = 0; chunkIndex < studentChunks.length; chunkIndex += 1) {
+      let pendingStudents = studentChunks[chunkIndex];
+
+      for (let attempt = 1; attempt <= COHORT_ANALYSIS_MAX_ATTEMPTS; attempt += 1) {
+        const batchStart = chunkIndex * COHORT_ANALYSIS_CHUNK_SIZE + 1;
+        const batchEnd = Math.min(
+          batchStart + pendingStudents.length - 1,
+          uncachedStudents.length,
+        );
+
+        setCohortProgress({
+          processed: resultsMap.size,
+          total: studentsForApi.length,
+          currentName:
+            attempt === 1
+              ? `Analyzing batch ${chunkIndex + 1} of ${studentChunks.length} (${batchStart}-${batchEnd} of ${uncachedStudents.length} uncached students)...`
+              : `Retrying ${pendingStudents.length} student${pendingStudents.length === 1 ? "" : "s"} in batch ${chunkIndex + 1} of ${studentChunks.length}...`,
+        });
+
+        const res = await fetch("/api/strategy-batch", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            students: pendingStudents,
+            classId,
+            assignmentId,
+          }),
+        });
+        const data = await parseJsonResponse<StrategyBatchResponse>(res);
+
+        for (const result of data?.results ?? []) {
+          resultsMap.set(result.id, result);
+        }
+
+        const orderedResults = studentsForApi
+          .filter((student) => resultsMap.has(student.id))
+          .map((student) => resultsMap.get(student.id) as StudentStrategyResult);
+        setCohortResults(orderedResults);
+        setCohortProgress({
+          processed: orderedResults.length,
+          total: studentsForApi.length,
+          currentName:
+            orderedResults.length < studentsForApi.length
+              ? `Completed ${orderedResults.length} of ${studentsForApi.length} students.`
+              : "Finalizing cohort recommendation...",
+        });
+
+        const failedStudents = pendingStudents.filter((student) =>
+          (data?.errors ?? []).some((error) => error.id === student.id),
+        );
+
+        if (res.ok && failedStudents.length === 0) {
+          break;
+        }
+
+        const isRetryable =
+          res.status === 0 ||
+          res.status === 502 ||
+          res.status === 503 ||
+          res.status === 504 ||
+          failedStudents.length > 0;
+        if (isRetryable && attempt < COHORT_ANALYSIS_MAX_ATTEMPTS) {
+          pendingStudents = failedStudents.length > 0 ? failedStudents : pendingStudents;
+          await delay(1000 * attempt);
+          continue;
+        }
+
+        if (failedStudents.length > 0) {
+          const failedNames = failedStudents.map((student) => student.name).join(", ");
+          throw new Error(
+            `Failed to analyze ${failedStudents.length} student${failedStudents.length === 1 ? "" : "s"} after retry: ${failedNames}.`,
+          );
+        }
+
+        if (!res.ok) {
+          throw new Error(
+            formatStrategyBatchError(res.status, data?.error),
+          );
+        }
+
+        throw new Error("Cohort analysis returned an invalid response.");
+      }
+    }
+  };
+
   const requestCohortAnalysis = async () => {
     if (!classId || !assignmentId) return;
     if (studentAnswers.length === 0) {
@@ -1061,6 +1208,7 @@ export default function TeacherView({ user }: Props) {
     setCohortProgress({ processed: 0, total: studentAnswers.length, currentName: "Loading cache..." });
 
     try {
+      let cohortWarning: string | null = null;
       const studentsForApi = studentAnswers.map((sa) => ({
         id: sa.student_id,
         name: sa.student_name,
@@ -1105,91 +1253,95 @@ export default function TeacherView({ user }: Props) {
       const uncachedStudents = studentsForApi.filter(
         (student) => !cachedMap.has(student.id),
       );
-      const studentChunks = chunkItems(
-        uncachedStudents,
-        COHORT_ANALYSIS_CHUNK_SIZE,
-      );
+      if (uncachedStudents.length > 0) {
+        const startRes = await fetch("/api/strategy-job", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            students: uncachedStudents,
+            classId,
+            assignmentId,
+          }),
+        });
+        const startData = await parseJsonResponse<StrategyJobStartResponse>(startRes);
 
-      for (let chunkIndex = 0; chunkIndex < studentChunks.length; chunkIndex += 1) {
-        let pendingStudents = studentChunks[chunkIndex];
-
-        for (let attempt = 1; attempt <= COHORT_ANALYSIS_MAX_ATTEMPTS; attempt += 1) {
-          const batchStart = chunkIndex * COHORT_ANALYSIS_CHUNK_SIZE + 1;
-          const batchEnd = Math.min(
-            batchStart + pendingStudents.length - 1,
-            uncachedStudents.length,
-          );
-
-          setCohortProgress({
-            processed: resultsMap.size,
-            total: studentsForApi.length,
-            currentName:
-              attempt === 1
-                ? `Analyzing batch ${chunkIndex + 1} of ${studentChunks.length} (${batchStart}-${batchEnd} of ${uncachedStudents.length} uncached students)...`
-                : `Retrying ${pendingStudents.length} student${pendingStudents.length === 1 ? "" : "s"} in batch ${chunkIndex + 1} of ${studentChunks.length}...`,
+        if (startRes.status === 501) {
+          await runSynchronousCohortAnalysis({
+            studentsForApi,
+            uncachedStudents,
+            resultsMap,
           });
-          const res = await fetch("/api/strategy-batch", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              students: pendingStudents,
-              classId,
-              assignmentId,
-            }),
-          });
-          const data = await parseJsonResponse<StrategyBatchResponse>(res);
-
-          for (const result of data?.results ?? []) {
-            resultsMap.set(result.id, result);
-          }
-
-          const orderedResults = studentsForApi
-            .filter((student) => resultsMap.has(student.id))
-            .map((student) => resultsMap.get(student.id) as StudentStrategyResult);
-          setCohortResults(orderedResults);
-          setCohortProgress({
-            processed: orderedResults.length,
-            total: studentsForApi.length,
-            currentName:
-              orderedResults.length < studentsForApi.length
-                ? `Completed ${orderedResults.length} of ${studentsForApi.length} students.`
-                : "Finalizing cohort recommendation...",
-          });
-
-          const failedStudents = pendingStudents.filter((student) =>
-            (data?.errors ?? []).some((error) => error.id === student.id),
-          );
-
-          if (res.ok && failedStudents.length === 0) {
-            break;
-          }
-
-          const isRetryable =
-            res.status === 0 ||
-            res.status === 502 ||
-            res.status === 503 ||
-            res.status === 504 ||
-            failedStudents.length > 0;
-          if (isRetryable && attempt < COHORT_ANALYSIS_MAX_ATTEMPTS) {
-            pendingStudents = failedStudents.length > 0 ? failedStudents : pendingStudents;
-            await delay(1000 * attempt);
-            continue;
-          }
-
-          if (failedStudents.length > 0) {
-            const failedNames = failedStudents.map((student) => student.name).join(", ");
+        } else {
+          if (!startRes.ok || !startData?.jobId) {
             throw new Error(
-              `Failed to analyze ${failedStudents.length} student${failedStudents.length === 1 ? "" : "s"} after retry: ${failedNames}.`,
+              startData?.error ?? "Failed to start cohort analysis.",
             );
           }
 
-          if (!res.ok) {
-            throw new Error(
-              formatStrategyBatchError(res.status, data?.error),
+          for (;;) {
+            const statusRes = await fetch(
+              `/api/strategy-job/${encodeURIComponent(startData.jobId)}`,
+              {
+                cache: "no-store",
+              },
             );
-          }
+            const statusData = await parseJsonResponse<StrategyJobStatusResponse>(statusRes);
 
-          throw new Error("Cohort analysis returned an invalid response.");
+            if (!statusRes.ok || !statusData?.job) {
+              throw new Error(
+                statusData?.error ?? "Failed to load cohort analysis status.",
+              );
+            }
+
+            for (const result of statusData.results ?? []) {
+              resultsMap.set(result.id, result);
+            }
+
+            const orderedResults = studentsForApi
+              .filter((student) => resultsMap.has(student.id))
+              .map((student) => resultsMap.get(student.id) as StudentStrategyResult);
+            setCohortResults(orderedResults);
+
+            const processedStudents = statusData.job.processedStudents ?? 0;
+            const queuedStudents = statusData.job.totalStudents ?? uncachedStudents.length;
+            const terminal = isTerminalCohortJobStatus(statusData.job.status);
+
+            setCohortProgress({
+              processed: Math.min(
+                studentsForApi.length,
+                initialResults.length + processedStudents,
+              ),
+              total: studentsForApi.length,
+              currentName: terminal
+                ? "Finalizing cohort recommendation..."
+                : statusData.job.status === "queued"
+                  ? `Queued ${queuedStudents} uncached student${queuedStudents === 1 ? "" : "s"} for analysis...`
+                  : `Analyzing ${processedStudents} of ${queuedStudents} uncached student${queuedStudents === 1 ? "" : "s"}...`,
+            });
+
+            if (terminal) {
+              if (statusData.job.status === "failed_to_queue") {
+                throw new Error(
+                  statusData.job.errorMessage ?? "Failed to queue cohort analysis.",
+                );
+              }
+
+              if ((statusData.job.failedStudents ?? 0) > 0) {
+                const failedNames = (statusData.errors ?? [])
+                  .map((error) => error.name)
+                  .filter((name): name is string => Boolean(name))
+                  .join(", ");
+                cohortWarning =
+                  failedNames.length > 0
+                    ? `Finished with ${statusData.job.failedStudents} failed student${statusData.job.failedStudents === 1 ? "" : "s"}: ${failedNames}.`
+                    : `Finished with ${statusData.job.failedStudents} failed student${statusData.job.failedStudents === 1 ? "" : "s"}.`;
+              }
+
+              break;
+            }
+
+            await delay(COHORT_ANALYSIS_JOB_POLL_MS);
+          }
         }
       }
 
@@ -1207,6 +1359,10 @@ export default function TeacherView({ user }: Props) {
       if (masterPlan) {
         setPlan(masterPlan);
         setSelectedStrategies([masterPlan.strategy]);
+      }
+
+      if (cohortWarning) {
+        setError(cohortWarning);
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : "Unexpected error.");

--- a/app/components/TeacherView.tsx
+++ b/app/components/TeacherView.tsx
@@ -77,6 +77,10 @@ type StrategyJobStatusResponse = {
 
 type StrategyJobStatus = NonNullable<StrategyJobStatusResponse["job"]>["status"];
 
+type CohortAnalysisRequestOptions = {
+  forceRefresh?: boolean;
+};
+
 const COHORT_ANALYSIS_CHUNK_SIZE = 4;
 const COHORT_ANALYSIS_MAX_ATTEMPTS = 2;
 const COHORT_ANALYSIS_JOB_POLL_MS = 1500;
@@ -1093,11 +1097,13 @@ export default function TeacherView({ user }: Props) {
   }, [loadingCohort]);
 
   const runSynchronousCohortAnalysis = async ({
+    forceRefresh,
     lessonNumber,
     studentsForApi,
     uncachedStudents,
     resultsMap,
   }: {
+    forceRefresh: boolean;
     lessonNumber: number;
     studentsForApi: Array<{
       id: string;
@@ -1113,6 +1119,8 @@ export default function TeacherView({ user }: Props) {
     }>;
     resultsMap: Map<string, StudentStrategyResult>;
   }) => {
+    const actionLabel = forceRefresh ? "Reanalyzing" : "Analyzing";
+    const studentScopeLabel = forceRefresh ? "students" : "uncached students";
     const studentChunks = chunkItems(
       uncachedStudents,
       COHORT_ANALYSIS_CHUNK_SIZE,
@@ -1133,7 +1141,7 @@ export default function TeacherView({ user }: Props) {
           total: studentsForApi.length,
           currentName:
             attempt === 1
-              ? `Analyzing batch ${chunkIndex + 1} of ${studentChunks.length} (${batchStart}-${batchEnd} of ${uncachedStudents.length} uncached students)...`
+              ? `${actionLabel} batch ${chunkIndex + 1} of ${studentChunks.length} (${batchStart}-${batchEnd} of ${uncachedStudents.length} ${studentScopeLabel})...`
               : `Retrying ${pendingStudents.length} student${pendingStudents.length === 1 ? "" : "s"} in batch ${chunkIndex + 1} of ${studentChunks.length}...`,
         });
 
@@ -1145,6 +1153,7 @@ export default function TeacherView({ user }: Props) {
             classId,
             assignmentId,
             lessonNumber,
+            forceRefresh,
           }),
         });
         const data = await parseJsonResponse<StrategyBatchResponse>(res);
@@ -1204,7 +1213,9 @@ export default function TeacherView({ user }: Props) {
     }
   };
 
-  const requestCohortAnalysis = async () => {
+  const requestCohortAnalysis = async ({
+    forceRefresh = false,
+  }: CohortAnalysisRequestOptions = {}) => {
     if (!classId || !assignmentId) return;
     if (!selectedLesson) {
       setError("Select a lesson before generating strategies.");
@@ -1226,7 +1237,13 @@ export default function TeacherView({ user }: Props) {
     setSelectedForPublish(new Set());
     setCohortResults([]);
     setCohortDistribution({});
-    setCohortProgress({ processed: 0, total: studentAnswers.length, currentName: "Loading cache..." });
+    setCohortProgress({
+      processed: 0,
+      total: studentAnswers.length,
+      currentName: forceRefresh
+        ? "Starting cohort reanalysis..."
+        : "Loading cache...",
+    });
 
     try {
       let cohortWarning: string | null = null;
@@ -1238,10 +1255,12 @@ export default function TeacherView({ user }: Props) {
       }));
 
       const cacheUrl = `/api/strategy-cache?classId=${encodeURIComponent(classId)}&assignmentId=${encodeURIComponent(assignmentId)}&lessonNumber=${encodeURIComponent(lessonNumber)}`;
-      const cacheRes = await fetch(cacheUrl);
       let cacheData: { results?: Array<{ studentId?: string; plan?: unknown }> } = { results: [] };
-      if (cacheRes.ok) {
-        cacheData = await cacheRes.json();
+      if (!forceRefresh) {
+        const cacheRes = await fetch(cacheUrl);
+        if (cacheRes.ok) {
+          cacheData = await cacheRes.json();
+        }
       }
 
       const cachedMap = new Map<string, Plan>();
@@ -1268,12 +1287,16 @@ export default function TeacherView({ user }: Props) {
         currentName:
           initialResults.length > 0
             ? `Loaded ${initialResults.length} cached student${initialResults.length === 1 ? "" : "s"}.`
-            : "Starting cohort analysis...",
+            : forceRefresh
+              ? "Starting cohort reanalysis..."
+              : "Starting cohort analysis...",
       });
 
-      const uncachedStudents = studentsForApi.filter(
-        (student) => !cachedMap.has(student.id),
-      );
+      const uncachedStudents = forceRefresh
+        ? studentsForApi
+        : studentsForApi.filter(
+            (student) => !cachedMap.has(student.id),
+          );
       if (uncachedStudents.length > 0) {
         const startRes = await fetch("/api/strategy-job", {
           method: "POST",
@@ -1283,6 +1306,7 @@ export default function TeacherView({ user }: Props) {
             classId,
             assignmentId,
             lessonNumber,
+            forceRefresh,
           }),
         });
         const startData = await parseJsonResponse<StrategyJobStartResponse>(startRes);
@@ -1292,14 +1316,17 @@ export default function TeacherView({ user }: Props) {
             .filter((name) => typeof name === "string" && name.length > 0);
           cohortWarning =
             missingEnv.length > 0
-              ? `Cohort analysis queue is not configured on this environment (${missingEnv.join(", ")}). Running inline analysis instead.`
-              : `${startData?.error ?? "Cohort analysis queue is not configured on this environment."} Running inline analysis instead.`;
+              ? `Cohort analysis queue is not configured on this environment (${missingEnv.join(", ")}). Running inline ${forceRefresh ? "reanalysis" : "analysis"} instead.`
+              : `${startData?.error ?? "Cohort analysis queue is not configured on this environment."} Running inline ${forceRefresh ? "reanalysis" : "analysis"} instead.`;
           setCohortProgress({
             processed: initialResults.length,
             total: studentsForApi.length,
-            currentName: "Queue not configured here; analyzing inline instead...",
+            currentName: forceRefresh
+              ? "Queue not configured here; reanalyzing inline instead..."
+              : "Queue not configured here; analyzing inline instead...",
           });
           await runSynchronousCohortAnalysis({
+            forceRefresh,
             lessonNumber,
             studentsForApi,
             uncachedStudents,
@@ -1349,8 +1376,12 @@ export default function TeacherView({ user }: Props) {
               currentName: terminal
                 ? "Finalizing cohort recommendation..."
                 : statusData.job.status === "queued"
-                  ? `Queued ${queuedStudents} uncached student${queuedStudents === 1 ? "" : "s"} for analysis...`
-                  : `Analyzing ${processedStudents} of ${queuedStudents} uncached student${queuedStudents === 1 ? "" : "s"}...`,
+                  ? forceRefresh
+                    ? `Queued ${queuedStudents} student${queuedStudents === 1 ? "" : "s"} for reanalysis...`
+                    : `Queued ${queuedStudents} uncached student${queuedStudents === 1 ? "" : "s"} for analysis...`
+                  : forceRefresh
+                    ? `Reanalyzing ${processedStudents} of ${queuedStudents} student${queuedStudents === 1 ? "" : "s"}...`
+                    : `Analyzing ${processedStudents} of ${queuedStudents} uncached student${queuedStudents === 1 ? "" : "s"}...`,
             });
 
             if (terminal) {
@@ -1836,12 +1867,26 @@ export default function TeacherView({ user }: Props) {
                         ?
                       </button>
                     </div>
-                    <p className="mt-1 text-sm text-slate-600">Generate strategies for all students who have answered.</p>
+                    <p className="mt-1 text-sm text-slate-600">Generate strategies for all students who have answered. Use reanalysis when you want to ignore cached recommendations and rerun every student.</p>
                   </div>
-                  <button type="button" onClick={requestCohortAnalysis} disabled={loadingCohort || studentAnswers.length === 0}
-                    className="inline-flex items-center justify-center rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:text-slate-400">
-                    {loadingCohort ? "Analyzing cohort..." : `Analyze ${studentAnswers.length} students`}
-                  </button>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => void requestCohortAnalysis()}
+                      disabled={loadingCohort || studentAnswers.length === 0}
+                      className="inline-flex items-center justify-center rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:text-slate-400"
+                    >
+                      {loadingCohort ? "Running..." : `Analyze ${studentAnswers.length} students`}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => void requestCohortAnalysis({ forceRefresh: true })}
+                      disabled={loadingCohort || studentAnswers.length === 0}
+                      className="inline-flex items-center justify-center rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
+                    >
+                      {loadingCohort ? "Running..." : "Reanalyze All"}
+                    </button>
+                  </div>
                 </div>
 
                 {showCohortHelp && (

--- a/lib/cohort-analysis-queue.ts
+++ b/lib/cohort-analysis-queue.ts
@@ -2,32 +2,30 @@ import { SendMessageBatchCommand, SQSClient } from "@aws-sdk/client-sqs";
 
 const DEFAULT_ENGAGE_AWS_REGION = "us-east-2";
 
-const queueUrl = process.env.COHORT_ANALYSIS_QUEUE_URL?.trim();
-const awsRegion = process.env.ENGAGE_AWS_REGION ?? DEFAULT_ENGAGE_AWS_REGION;
-const awsAccessKeyId = process.env.ENGAGE_AWS_ACCESS_KEY_ID;
-const awsSecretAccessKey = process.env.ENGAGE_AWS_SECRET_ACCESS_KEY;
-
-let sqsClient: SQSClient | null = null;
+const getQueueConfig = () => ({
+  queueUrl: process.env.COHORT_ANALYSIS_QUEUE_URL?.trim() ?? "",
+  awsRegion: process.env.ENGAGE_AWS_REGION ?? DEFAULT_ENGAGE_AWS_REGION,
+  awsAccessKeyId: process.env.ENGAGE_AWS_ACCESS_KEY_ID,
+  awsSecretAccessKey: process.env.ENGAGE_AWS_SECRET_ACCESS_KEY,
+});
 
 const getSqsClient = () => {
+  const { queueUrl, awsRegion, awsAccessKeyId, awsSecretAccessKey } =
+    getQueueConfig();
   if (!queueUrl) {
     return null;
   }
 
-  if (!sqsClient) {
-    sqsClient = new SQSClient({
-      region: awsRegion,
-      ...(awsAccessKeyId &&
-        awsSecretAccessKey && {
-          credentials: {
-            accessKeyId: awsAccessKeyId,
-            secretAccessKey: awsSecretAccessKey,
-          },
-        }),
-    });
-  }
-
-  return sqsClient;
+  return new SQSClient({
+    region: awsRegion,
+    ...(awsAccessKeyId &&
+      awsSecretAccessKey && {
+        credentials: {
+          accessKeyId: awsAccessKeyId,
+          secretAccessKey: awsSecretAccessKey,
+        },
+      }),
+  });
 };
 
 const chunkItems = <T,>(items: T[], size: number) => {
@@ -43,7 +41,19 @@ const chunkItems = <T,>(items: T[], size: number) => {
 const buildBatchEntryId = (chunkIndex: number, studentIndex: number) =>
   `student-${chunkIndex}-${studentIndex}`;
 
-export const isCohortAnalysisQueueConfigured = () => Boolean(queueUrl);
+export const getCohortAnalysisQueueConfigIssues = () => {
+  const { queueUrl } = getQueueConfig();
+  const issues: string[] = [];
+
+  if (!queueUrl) {
+    issues.push("COHORT_ANALYSIS_QUEUE_URL");
+  }
+
+  return issues;
+};
+
+export const isCohortAnalysisQueueConfigured = () =>
+  getCohortAnalysisQueueConfigIssues().length === 0;
 
 export const enqueueCohortJobStudents = async ({
   jobId,
@@ -65,6 +75,7 @@ export const enqueueCohortJobStudents = async ({
     answers: Record<string, string | undefined>;
   }>;
 }) => {
+  const { queueUrl } = getQueueConfig();
   if (!queueUrl) {
     throw new Error("COHORT_ANALYSIS_QUEUE_URL is not configured.");
   }

--- a/lib/cohort-analysis-queue.ts
+++ b/lib/cohort-analysis-queue.ts
@@ -1,0 +1,98 @@
+import { SendMessageBatchCommand, SQSClient } from "@aws-sdk/client-sqs";
+
+const DEFAULT_ENGAGE_AWS_REGION = "us-east-2";
+
+const queueUrl = process.env.COHORT_ANALYSIS_QUEUE_URL?.trim();
+const awsRegion = process.env.ENGAGE_AWS_REGION ?? DEFAULT_ENGAGE_AWS_REGION;
+const awsAccessKeyId = process.env.ENGAGE_AWS_ACCESS_KEY_ID;
+const awsSecretAccessKey = process.env.ENGAGE_AWS_SECRET_ACCESS_KEY;
+
+let sqsClient: SQSClient | null = null;
+
+const getSqsClient = () => {
+  if (!queueUrl) {
+    return null;
+  }
+
+  if (!sqsClient) {
+    sqsClient = new SQSClient({
+      region: awsRegion,
+      ...(awsAccessKeyId &&
+        awsSecretAccessKey && {
+          credentials: {
+            accessKeyId: awsAccessKeyId,
+            secretAccessKey: awsSecretAccessKey,
+          },
+        }),
+    });
+  }
+
+  return sqsClient;
+};
+
+const chunkItems = <T,>(items: T[], size: number) => {
+  const chunks: T[][] = [];
+
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+
+  return chunks;
+};
+
+export const isCohortAnalysisQueueConfigured = () => Boolean(queueUrl);
+
+export const enqueueCohortJobStudents = async ({
+  jobId,
+  classId,
+  assignmentId,
+  totalStudents,
+  students,
+}: {
+  jobId: string;
+  classId: string;
+  assignmentId: string;
+  totalStudents: number;
+  students: Array<{
+    id: string;
+    name: string;
+    assignment?: string;
+    answers: Record<string, string | undefined>;
+  }>;
+}) => {
+  if (!queueUrl) {
+    throw new Error("COHORT_ANALYSIS_QUEUE_URL is not configured.");
+  }
+
+  const client = getSqsClient();
+  if (!client) {
+    throw new Error("Failed to initialize the cohort analysis queue client.");
+  }
+
+  const chunks = chunkItems(students, 10);
+  for (const chunk of chunks) {
+    const response = await client.send(
+      new SendMessageBatchCommand({
+        QueueUrl: queueUrl,
+        Entries: chunk.map((student) => ({
+          Id: student.id,
+          MessageBody: JSON.stringify({
+            jobId,
+            classId,
+            assignmentId,
+            totalStudents,
+            student,
+          }),
+        })),
+      }),
+    );
+
+    if ((response.Failed ?? []).length > 0) {
+      const firstError = response.Failed?.[0];
+      throw new Error(
+        firstError?.Message ??
+          `Failed to enqueue ${response.Failed?.length ?? 1} student message(s).`,
+      );
+    }
+  }
+};

--- a/lib/cohort-analysis-queue.ts
+++ b/lib/cohort-analysis-queue.ts
@@ -61,6 +61,7 @@ export const enqueueCohortJobStudents = async ({
   assignmentId,
   lessonNumber,
   totalStudents,
+  forceRefresh = false,
   students,
 }: {
   jobId: string;
@@ -68,6 +69,7 @@ export const enqueueCohortJobStudents = async ({
   assignmentId: string;
   lessonNumber: number;
   totalStudents: number;
+  forceRefresh?: boolean;
   students: Array<{
     id: string;
     name: string;
@@ -99,6 +101,7 @@ export const enqueueCohortJobStudents = async ({
             assignmentId,
             lessonNumber,
             totalStudents,
+            forceRefresh,
             student,
           }),
         })),

--- a/lib/nosql.ts
+++ b/lib/nosql.ts
@@ -71,6 +71,34 @@ type ContentRatingRecord = {
   rated_at: string;
 };
 
+export type CohortJobRecord = {
+  job_id: string;
+  class_id: string;
+  assignment_id: string;
+  total_students: number;
+  processed_students: number;
+  completed_students: number;
+  failed_students: number;
+  status: "queued" | "running" | "completed" | "completed_with_errors" | "failed_to_queue";
+  error_message?: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type CohortJobStudentRecord = {
+  job_id: string;
+  class_id: string;
+  assignment_id: string;
+  student_id: string;
+  student_name: string;
+  status: "completed" | "failed";
+  source?: "cache" | "model" | null;
+  plan_json?: string;
+  timing?: Record<string, unknown>;
+  error?: string;
+  updated_at: string;
+};
+
 type Store = {
   strategy_cache: Record<string, StrategyCacheRecord>;
   teacher_annotations: TeacherAnnotation[];
@@ -79,6 +107,8 @@ type Store = {
   student_answers: StudentAnswerRecord[];
   content_publish: ContentPublishRecord[];
   content_ratings: ContentRatingRecord[];
+  cohort_jobs: CohortJobRecord[];
+  cohort_job_students: CohortJobStudentRecord[];
 };
 
 type TeacherAnnotation = {
@@ -108,6 +138,8 @@ const emptyStore: Store = {
   student_answers: [],
   content_publish: [],
   content_ratings: [],
+  cohort_jobs: [],
+  cohort_job_students: [],
 };
 const dataDir = path.join(process.cwd(), "data");
 const storePath = path.join(dataDir, "engage-nosql.json");
@@ -222,6 +254,12 @@ const loadStore = async () => {
       }
       if (!Array.isArray(parsed.content_ratings)) {
         parsed.content_ratings = [];
+      }
+      if (!Array.isArray(parsed.cohort_jobs)) {
+        parsed.cohort_jobs = [];
+      }
+      if (!Array.isArray(parsed.cohort_job_students)) {
+        parsed.cohort_job_students = [];
       }
       storeCache = parsed;
       return parsed;
@@ -406,6 +444,210 @@ export const listCachedPlans = async (
     });
   }
   return records;
+};
+
+const jobPk = (jobId: string) => `JOB#${jobId}`;
+
+const normalizeCohortJob = (
+  jobId: string,
+  item: Record<string, unknown>,
+): CohortJobRecord => ({
+  job_id: jobId,
+  class_id: (item.source_class_id as string) ?? "",
+  assignment_id: (item.source_assignment_id as string) ?? "",
+  total_students: Number(item.total_students ?? 0),
+  processed_students: Number(item.processed_students ?? 0),
+  completed_students: Number(item.completed_students ?? 0),
+  failed_students: Number(item.failed_students ?? 0),
+  status: ((item.status as string) ??
+    "queued") as CohortJobRecord["status"],
+  error_message: (item.error_message as string) ?? undefined,
+  created_at: (item.created_at as string) ?? "",
+  updated_at: (item.updated_at as string) ?? "",
+});
+
+const normalizeCohortJobStudent = (
+  jobId: string,
+  item: Record<string, unknown>,
+): CohortJobStudentRecord => ({
+  job_id: jobId,
+  class_id: (item.source_class_id as string) ?? "",
+  assignment_id: (item.source_assignment_id as string) ?? "",
+  student_id: toPlainStudentId(item.student_id as string, item.student_id as string),
+  student_name: (item.student_name as string) ?? "",
+  status: ((item.status as string) ??
+    "failed") as CohortJobStudentRecord["status"],
+  source: ((item.source as string) ?? null) as CohortJobStudentRecord["source"],
+  plan_json: (item.plan_json as string) ?? undefined,
+  timing: (item.timing as Record<string, unknown>) ?? undefined,
+  error: (item.error as string) ?? undefined,
+  updated_at: (item.updated_at as string) ?? "",
+});
+
+export const createCohortJob = async (
+  jobId: string,
+  classId: string,
+  assignmentId: string,
+  totalStudents: number,
+): Promise<CohortJobRecord> => {
+  const timestamp = new Date().toISOString();
+  const record: CohortJobRecord = {
+    job_id: jobId,
+    class_id: classId,
+    assignment_id: assignmentId,
+    total_students: totalStudents,
+    processed_students: 0,
+    completed_students: 0,
+    failed_students: 0,
+    status: "queued",
+    created_at: timestamp,
+    updated_at: timestamp,
+  };
+
+  if (useDynamoDb) {
+    const client = getDynamoClient();
+    if (client) {
+      await client.send(
+        new PutCommand({
+          TableName: dynamoTableName,
+          Item: {
+            [pkField]: jobPk(jobId),
+            [skField]: "META",
+            record_type: "cohort_job",
+            source_class_id: classId,
+            source_assignment_id: assignmentId,
+            total_students: totalStudents,
+            processed_students: 0,
+            completed_students: 0,
+            failed_students: 0,
+            status: "queued",
+            created_at: timestamp,
+            updated_at: timestamp,
+          },
+        }),
+      );
+    }
+    return record;
+  }
+
+  await withWriteLock(async () => {
+    const store = await loadStore();
+    const nextJobs = store.cohort_jobs.filter((job) => job.job_id !== jobId);
+    nextJobs.push(record);
+    store.cohort_jobs = nextJobs;
+    await persistStore(store);
+  });
+
+  return record;
+};
+
+export const setCohortJobStatus = async (
+  jobId: string,
+  status: CohortJobRecord["status"],
+  errorMessage?: string,
+) => {
+  const updatedAt = new Date().toISOString();
+
+  if (useDynamoDb) {
+    const client = getDynamoClient();
+    if (client) {
+      const current = await getCohortJob(jobId);
+      if (!current.job) {
+        return null;
+      }
+      const nextJob: CohortJobRecord = {
+        ...current.job,
+        status,
+        ...(errorMessage ? { error_message: errorMessage } : {}),
+        updated_at: updatedAt,
+      };
+      await client.send(
+        new PutCommand({
+          TableName: dynamoTableName,
+          Item: {
+            [pkField]: jobPk(jobId),
+            [skField]: "META",
+            record_type: "cohort_job",
+            source_class_id: nextJob.class_id,
+            source_assignment_id: nextJob.assignment_id,
+            total_students: nextJob.total_students,
+            processed_students: nextJob.processed_students,
+            completed_students: nextJob.completed_students,
+            failed_students: nextJob.failed_students,
+            status: nextJob.status,
+            error_message: nextJob.error_message,
+            created_at: nextJob.created_at,
+            updated_at: nextJob.updated_at,
+          },
+        }),
+      );
+      return nextJob;
+    }
+    return null;
+  }
+
+  let nextJob: CohortJobRecord | null = null;
+  await withWriteLock(async () => {
+    const store = await loadStore();
+    const index = store.cohort_jobs.findIndex((job) => job.job_id === jobId);
+    if (index < 0) {
+      return;
+    }
+    nextJob = {
+      ...store.cohort_jobs[index],
+      status,
+      ...(errorMessage ? { error_message: errorMessage } : {}),
+      updated_at: updatedAt,
+    };
+    store.cohort_jobs[index] = nextJob;
+    await persistStore(store);
+  });
+  return nextJob;
+};
+
+export const getCohortJob = async (
+  jobId: string,
+): Promise<{ job: CohortJobRecord | null; students: CohortJobStudentRecord[] }> => {
+  if (useDynamoDb) {
+    const client = getDynamoClient();
+    if (!client) {
+      return { job: null, students: [] };
+    }
+
+    const result = await client.send(
+      new QueryCommand({
+        TableName: dynamoTableName,
+        KeyConditionExpression: "#pk = :pk",
+        ExpressionAttributeNames: {
+          "#pk": pkField,
+        },
+        ExpressionAttributeValues: {
+          ":pk": jobPk(jobId),
+        },
+      }),
+    );
+
+    let job: CohortJobRecord | null = null;
+    const students: CohortJobStudentRecord[] = [];
+
+    for (const item of result.Items ?? []) {
+      if (item.record_type === "cohort_job") {
+        job = normalizeCohortJob(jobId, item);
+        continue;
+      }
+      if (item.record_type === "cohort_job_student") {
+        students.push(normalizeCohortJobStudent(jobId, item));
+      }
+    }
+
+    return { job, students };
+  }
+
+  const store = await loadStore();
+  return {
+    job: store.cohort_jobs.find((record) => record.job_id === jobId) ?? null,
+    students: store.cohort_job_students.filter((record) => record.job_id === jobId),
+  };
 };
 
 export const recordTeacherAnnotation = async (

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.985.0",
         "@aws-sdk/client-s3": "^3.988.0",
+        "@aws-sdk/client-sqs": "^3.1016.0",
         "@aws-sdk/lib-dynamodb": "^3.985.0",
         "@aws-sdk/s3-request-presigner": "^3.988.0",
         "dotenv": "^16.5.0",
@@ -447,65 +448,68 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-sso": {
-      "version": "3.988.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.988.0.tgz",
-      "integrity": "sha512-ThqQ7aF1k0Zz4yJRwegHw+T1rM3a7ZPvvEUSEdvn5Z8zTeWgJAbtqW/6ejPsMLmFOlHgNcwDQN/e69OvtEOoIQ==",
+    "node_modules/@aws-sdk/client-sqs": {
+      "version": "3.1016.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.1016.0.tgz",
+      "integrity": "sha512-31OP7m98ZXuHF7DbOapmjp2hJyrduwwNaZPYrPyDcSTZ+60Qg+F/AUA6snw+QpOPfVnxFqkofhxyBKPPbaQWig==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.8",
-        "@aws-sdk/middleware-host-header": "^3.972.3",
-        "@aws-sdk/middleware-logger": "^3.972.3",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.3",
-        "@aws-sdk/middleware-user-agent": "^3.972.8",
-        "@aws-sdk/region-config-resolver": "^3.972.3",
-        "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.988.0",
-        "@aws-sdk/util-user-agent-browser": "^3.972.3",
-        "@aws-sdk/util-user-agent-node": "^3.972.6",
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/core": "^3.23.0",
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/hash-node": "^4.2.8",
-        "@smithy/invalid-dependency": "^4.2.8",
-        "@smithy/middleware-content-length": "^4.2.8",
-        "@smithy/middleware-endpoint": "^4.4.14",
-        "@smithy/middleware-retry": "^4.4.31",
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/middleware-stack": "^4.2.8",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/node-http-handler": "^4.4.10",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.11.3",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.30",
-        "@smithy/util-defaults-mode-node": "^4.2.33",
-        "@smithy/util-endpoints": "^3.2.8",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-retry": "^4.2.8",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/credential-provider-node": "^3.972.25",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+        "@aws-sdk/middleware-sdk-sqs": "^3.972.17",
+        "@aws-sdk/middleware-user-agent": "^3.972.25",
+        "@aws-sdk/region-config-resolver": "^3.972.9",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.11",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/core": "^3.23.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/md5-js": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.27",
+        "@smithy/middleware-retry": "^4.4.44",
+        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.43",
+        "@smithy/util-defaults-mode-node": "^4.2.47",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.988.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.988.0.tgz",
-      "integrity": "sha512-HuXu4boeUWU0DQiLslbgdvuQ4ZMCo4Lsk97w8BIUokql2o9MvjE5dwqI5pzGt0K7afO1FybjidUQVTMLuZNTOA==",
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.996.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
+      "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-endpoints": "^3.2.8",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-endpoints": "^3.3.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -513,23 +517,23 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.973.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.8.tgz",
-      "integrity": "sha512-WeYJ2sfvRLbbUIrjGMUXcEHGu5SJk53jz3K9F8vFP42zWyROzPJ2NB6lMu9vWl5hnMwzwabX7pJc9Euh3JyMGw==",
+      "version": "3.973.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.24.tgz",
+      "integrity": "sha512-vvf82RYQu2GidWAuQq+uIzaPz9V0gSCXVqdVzRosgl5rXcspXOpSD3wFreGGW6AYymPr97Z69kjVnLePBxloDw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/xml-builder": "^3.972.4",
-        "@smithy/core": "^3.23.0",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/signature-v4": "^5.3.8",
-        "@smithy/smithy-client": "^4.11.3",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/xml-builder": "^3.972.15",
+        "@smithy/core": "^3.23.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/signature-v4": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -550,15 +554,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.6.tgz",
-      "integrity": "sha512-+dYEBWgTqkQQHFUllvBL8SLyXyLKWdxLMD1LmKJRvmb0NMJuaJFG/qg78C+LE67eeGbipYcE+gJ48VlLBGHlMw==",
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.22.tgz",
+      "integrity": "sha512-cXp0VTDWT76p3hyK5D51yIKEfpf6/zsUvMfaB8CkyqadJxMQ8SbEeVroregmDlZbtG31wkj9ei0WnftmieggLg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.8",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -566,20 +570,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.8.tgz",
-      "integrity": "sha512-z3QkozMV8kOFisN2pgRag/f0zPDrw96mY+ejAM0xssV/+YQ2kklbylRNI/TcTQUDnGg0yPxNjyV6F2EM2zPTwg==",
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.24.tgz",
+      "integrity": "sha512-h694K7+tRuepSRJr09wTvQfaEnjzsKZ5s7fbESrVds02GT/QzViJ94/HCNwM7bUfFxqpPXHxulZfL6Cou0dwPg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.8",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/node-http-handler": "^4.4.10",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.11.3",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-stream": "^4.5.12",
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-stream": "^4.5.20",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -587,24 +591,24 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.6.tgz",
-      "integrity": "sha512-6tkIYFv3sZH1XsjQq+veOmx8XWRnyqTZ5zx/sMtdu/xFRIzrJM1Y2wAXeCJL1rhYSB7uJSZ1PgALI2WVTj78ow==",
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.24.tgz",
+      "integrity": "sha512-O46fFmv0RDFWiWEA9/e6oW92BnsyAXuEgTTasxHligjn2RCr9L/DK773m/NoFaL3ZdNAUz8WxgxunleMnHAkeQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.8",
-        "@aws-sdk/credential-provider-env": "^3.972.6",
-        "@aws-sdk/credential-provider-http": "^3.972.8",
-        "@aws-sdk/credential-provider-login": "^3.972.6",
-        "@aws-sdk/credential-provider-process": "^3.972.6",
-        "@aws-sdk/credential-provider-sso": "^3.972.6",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.6",
-        "@aws-sdk/nested-clients": "3.988.0",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/credential-provider-imds": "^4.2.8",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/credential-provider-env": "^3.972.22",
+        "@aws-sdk/credential-provider-http": "^3.972.24",
+        "@aws-sdk/credential-provider-login": "^3.972.24",
+        "@aws-sdk/credential-provider-process": "^3.972.22",
+        "@aws-sdk/credential-provider-sso": "^3.972.24",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.24",
+        "@aws-sdk/nested-clients": "^3.996.14",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -612,18 +616,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.6.tgz",
-      "integrity": "sha512-LXsoBoaTSGHdRCQXlWSA0CHHh05KWncb592h9ElklnPus++8kYn1Ic6acBR4LKFQ0RjjMVgwe5ypUpmTSUOjPA==",
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.24.tgz",
+      "integrity": "sha512-sIk8oa6AzDoUhxsR11svZESqvzGuXesw62Rl2oW6wguZx8i9cdGCvkFg+h5K7iucUZP8wyWibUbJMc+J66cu5g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.8",
-        "@aws-sdk/nested-clients": "3.988.0",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/nested-clients": "^3.996.14",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -631,22 +635,22 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.7.tgz",
-      "integrity": "sha512-PuJ1IkISG7ZDpBFYpGotaay6dYtmriBYuHJ/Oko4VHxh8YN5vfoWnMNYFEWuzOfyLmP7o9kDVW0BlYIpb3skvw==",
+      "version": "3.972.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.25.tgz",
+      "integrity": "sha512-m7dR0Dsva2P+VUpL+VkC0WwiDby5pgmWXkRVDB5rlwv0jXJrQJf7YMtCoM8Wjk0H9jPeCYOxOXXcIgp/qp5Alg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.6",
-        "@aws-sdk/credential-provider-http": "^3.972.8",
-        "@aws-sdk/credential-provider-ini": "^3.972.6",
-        "@aws-sdk/credential-provider-process": "^3.972.6",
-        "@aws-sdk/credential-provider-sso": "^3.972.6",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.6",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/credential-provider-imds": "^4.2.8",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/credential-provider-env": "^3.972.22",
+        "@aws-sdk/credential-provider-http": "^3.972.24",
+        "@aws-sdk/credential-provider-ini": "^3.972.24",
+        "@aws-sdk/credential-provider-process": "^3.972.22",
+        "@aws-sdk/credential-provider-sso": "^3.972.24",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.24",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -654,16 +658,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.6.tgz",
-      "integrity": "sha512-Yf34cjIZJHVnD92jnVYy3tNjM+Q4WJtffLK2Ehn0nKpZfqd1m7SI0ra22Lym4C53ED76oZENVSS2wimoXJtChQ==",
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.22.tgz",
+      "integrity": "sha512-Os32s8/4gTZjBk5BtoS/cuTILaj+K72d0dVG7TCJX/fC4598cxwLDmf1AEHEpER5oL3K//yETjvFaz0V8oO5Xw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.8",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -671,18 +675,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.6.tgz",
-      "integrity": "sha512-2+5UVwUYdD4BBOkLpKJ11MQ8wQeyJGDVMDRH5eWOULAh9d6HJq07R69M/mNNMC9NTjr3mB1T0KGDn4qyQh5jzg==",
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.24.tgz",
+      "integrity": "sha512-PaFv7snEfypU2yXkpvfyWgddEbDLtgVe51wdZlinhc2doubBjUzJZZpgwuF2Jenl1FBydMhNpMjD6SBUM3qdSA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.988.0",
-        "@aws-sdk/core": "^3.973.8",
-        "@aws-sdk/token-providers": "3.988.0",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/nested-clients": "^3.996.14",
+        "@aws-sdk/token-providers": "3.1015.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -690,17 +694,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.6.tgz",
-      "integrity": "sha512-pdJzwKtlDxBnvZ04pWMqttijmkUIlwOsS0GcxCjzEVyUMpARysl0S0ks74+gs2Pdev3Ujz+BTAjOc1tQgAxGqA==",
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.24.tgz",
+      "integrity": "sha512-J6H4R1nvr3uBTqD/EeIPAskrBtET4WFfNhpFySr2xW7bVZOXpQfPjrLSIx65jcNjBmLXzWq8QFLdVoGxiGG/SA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.8",
-        "@aws-sdk/nested-clients": "3.988.0",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/nested-clients": "^3.996.14",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -833,14 +837,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.3.tgz",
-      "integrity": "sha512-aknPTb2M+G3s+0qLCx4Li/qGZH8IIYjugHMv15JTYMe6mgZO8VBpYgeGYsNMGCqCZOcWzuf900jFBG5bopfzmA==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.8.tgz",
+      "integrity": "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -862,13 +866,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.3.tgz",
-      "integrity": "sha512-Ftg09xNNRqaz9QNzlfdQWfpqMCJbsQdnZVJP55jfhbKi1+FTWxGuvfPoBhDHIovqWKjqbuiew3HuhxbJ0+OjgA==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.8.tgz",
+      "integrity": "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -876,15 +880,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.3.tgz",
-      "integrity": "sha512-PY57QhzNuXHnwbJgbWYTrqIDHYSeOlhfYERTAuc16LKZpTZRJUjzBFokp9hF7u1fuGeE3D70ERXzdbMBOqQz7Q==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.8.tgz",
+      "integrity": "sha512-BnnvYs2ZEpdlmZ2PNlV2ZyQ8j8AEkMTjN79y/YA475ER1ByFYrkVR85qmhni8oeTaJcDqbx364wDpitDAA/wCA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
+        "@aws-sdk/types": "^3.973.6",
         "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -916,6 +920,23 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/middleware-sdk-sqs": {
+      "version": "3.972.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.972.17.tgz",
+      "integrity": "sha512-LnzPRRoDXGtlFV2G1p2rsY6fRKrbf6Pvvc21KliSLw3+NmQca2+Aa1QIMRbpQvZYedsSqkGYwxe+qvXwQ2uxDw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/middleware-ssec": {
       "version": "3.972.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.3.tgz",
@@ -931,17 +952,18 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.8.tgz",
-      "integrity": "sha512-3PGL+Kvh1PhB0EeJeqNqOWQgipdqFheO4OUKc6aYiFwEpM5t9AyE5hjjxZ5X6iSj8JiduWFZLPwASzF6wQRgFg==",
+      "version": "3.972.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.25.tgz",
+      "integrity": "sha512-QxiMPofvOt8SwSynTOmuZfvvPM1S9QfkESBxB22NMHTRXCJhR5BygLl8IXfC4jELiisQgwsgUby21GtXfX3f/g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.8",
-        "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.988.0",
-        "@smithy/core": "^3.23.0",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@smithy/core": "^3.23.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-retry": "^4.2.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -949,15 +971,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.988.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.988.0.tgz",
-      "integrity": "sha512-HuXu4boeUWU0DQiLslbgdvuQ4ZMCo4Lsk97w8BIUokql2o9MvjE5dwqI5pzGt0K7afO1FybjidUQVTMLuZNTOA==",
+      "version": "3.996.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
+      "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-endpoints": "^3.2.8",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-endpoints": "^3.3.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -965,48 +987,48 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.988.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.988.0.tgz",
-      "integrity": "sha512-OgYV9k1oBCQ6dOM+wWAMNNehXA8L4iwr7ydFV+JDHyuuu0Ko7tDXnLEtEmeQGYRcAFU3MGasmlBkMB8vf4POrg==",
+      "version": "3.996.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.14.tgz",
+      "integrity": "sha512-fSESKvh1VbfjtV3QMnRkCPZWkUbQof6T/DOpiLp33yP2wA+rbwwnZeG3XT3Ekljgw2I8X4XaQPnw+zSR8yxJ5Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.8",
-        "@aws-sdk/middleware-host-header": "^3.972.3",
-        "@aws-sdk/middleware-logger": "^3.972.3",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.3",
-        "@aws-sdk/middleware-user-agent": "^3.972.8",
-        "@aws-sdk/region-config-resolver": "^3.972.3",
-        "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.988.0",
-        "@aws-sdk/util-user-agent-browser": "^3.972.3",
-        "@aws-sdk/util-user-agent-node": "^3.972.6",
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/core": "^3.23.0",
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/hash-node": "^4.2.8",
-        "@smithy/invalid-dependency": "^4.2.8",
-        "@smithy/middleware-content-length": "^4.2.8",
-        "@smithy/middleware-endpoint": "^4.4.14",
-        "@smithy/middleware-retry": "^4.4.31",
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/middleware-stack": "^4.2.8",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/node-http-handler": "^4.4.10",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.11.3",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.30",
-        "@smithy/util-defaults-mode-node": "^4.2.33",
-        "@smithy/util-endpoints": "^3.2.8",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-retry": "^4.2.8",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+        "@aws-sdk/middleware-user-agent": "^3.972.25",
+        "@aws-sdk/region-config-resolver": "^3.972.9",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.11",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/core": "^3.23.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.27",
+        "@smithy/middleware-retry": "^4.4.44",
+        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.43",
+        "@smithy/util-defaults-mode-node": "^4.2.47",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1014,15 +1036,15 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.988.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.988.0.tgz",
-      "integrity": "sha512-HuXu4boeUWU0DQiLslbgdvuQ4ZMCo4Lsk97w8BIUokql2o9MvjE5dwqI5pzGt0K7afO1FybjidUQVTMLuZNTOA==",
+      "version": "3.996.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
+      "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-endpoints": "^3.2.8",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-endpoints": "^3.3.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1030,15 +1052,15 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.3.tgz",
-      "integrity": "sha512-v4J8qYAWfOMcZ4MJUyatntOicTzEMaU7j3OpkRCGGFSL2NgXQ5VbxauIyORA+pxdKZ0qQG2tCQjQjZDlXEC3Ow==",
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.9.tgz",
+      "integrity": "sha512-eQ+dFU05ZRC/lC2XpYlYSPlXtX3VT8sn5toxN2Fv7EXlMoA2p9V7vUBKqHunfD4TRLpxUq8Y8Ol/nCqiv327Ng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1082,17 +1104,17 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.988.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.988.0.tgz",
-      "integrity": "sha512-xvXVlRVKHnF2h6fgWBm64aPP5J+58aJyGfRrQa/uFh8a9mcK68mLfJOYq+ZSxQy/UN3McafJ2ILAy7IWzT9kRw==",
+      "version": "3.1015.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1015.0.tgz",
+      "integrity": "sha512-3OSD4y110nisRhHzFOjoEeHU4GQL4KpzkX9PxzWaiZe0Yg2+thZKM0Pn9DjYwezH5JYfh/K++xK/SE0IHGrmCQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.8",
-        "@aws-sdk/nested-clients": "3.988.0",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/nested-clients": "^3.996.14",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1100,12 +1122,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
-      "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
+      "version": "3.973.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
+      "integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1183,27 +1205,28 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.3.tgz",
-      "integrity": "sha512-JurOwkRUcXD/5MTDBcqdyQ9eVedtAsZgw5rBwktsPTN7QtPiS2Ld1jkJepNgYoCufz1Wcut9iup7GJDoIHp8Fw==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.8.tgz",
+      "integrity": "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.972.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.972.6.tgz",
-      "integrity": "sha512-966xH8TPqkqOXP7EwnEThcKKz0SNP9kVJBKd9M8bNXE4GSqVouMKKnFBwYnzbWVKuLXubzX5seokcX4a0JLJIA==",
+      "version": "3.973.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.11.tgz",
+      "integrity": "sha512-1qdXbXo2s5MMLpUvw00284LsbhtlQ4ul7Zzdn5n+7p4WVgCMLqhxImpHIrjSoc72E/fyc4Wq8dLtUld2Gsh+lA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.8",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/middleware-user-agent": "^3.972.25",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1219,13 +1242,13 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.4.tgz",
-      "integrity": "sha512-0zJ05ANfYqI6+rGqj8samZBFod0dPPousBjLEqg8WdxSgbMAkRgLyn81lP215Do0rFJ/17LIXwr7q0yK24mP6Q==",
+      "version": "3.972.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.15.tgz",
+      "integrity": "sha512-PxMRlCFNiQnke9YR29vjFQwz4jq+6Q04rOVFeTDR2K7Qpv9h9FOWOxG+zJjageimYbWqE3bTuLjmryWHAWbvaA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "fast-xml-parser": "5.3.4",
+        "@smithy/types": "^4.13.1",
+        "fast-xml-parser": "5.5.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3422,12 +3445,12 @@
       "license": "MIT"
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.8.tgz",
-      "integrity": "sha512-peuVfkYHAmS5ybKxWcfraK7WBBP0J+rkfUcbHJJKQ4ir3UAUNQI+Y4Vt/PqSzGqgloJ5O1dk7+WzNL8wcCSXbw==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.12.tgz",
+      "integrity": "sha512-xolrFw6b+2iYGl6EcOL7IJY71vvyZ0DJ3mcKtpykqPe2uscwtzDZJa1uVQXyP7w9Dd+kGwYnPbMsJrGISKiY/Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3460,16 +3483,16 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.6.tgz",
-      "integrity": "sha512-qJpzYC64kaj3S0fueiu3kXm8xPrR3PcXDPEgnaNMRn0EjNSZFoFjvbUp0YUDsRhN1CB90EnHJtbxWKevnH99UQ==",
+      "version": "4.4.13",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.13.tgz",
+      "integrity": "sha512-iIzMC5NmOUP6WL6o8iPBjFhUhBZ9pPjpUpQYWMUFQqKyXXzOftbfK8zcQCz/jFV1Psmf05BK5ypx4K2r4Tnwdg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-config-provider": "^4.2.0",
-        "@smithy/util-endpoints": "^3.2.8",
-        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3477,20 +3500,20 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.0.tgz",
-      "integrity": "sha512-Yq4UPVoQICM9zHnByLmG8632t2M0+yap4T7ANVw482J0W7HW0pOuxwVmeOwzJqX2Q89fkXz0Vybz55Wj2Xzrsg==",
+      "version": "3.23.12",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.12.tgz",
+      "integrity": "sha512-o9VycsYNtgC+Dy3I0yrwCqv9CWicDnke0L7EVOrZtJpjb2t0EjaEofmMrYc0T1Kn3yk32zm6cspxF9u9Bj7e5w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-stream": "^4.5.12",
-        "@smithy/util-utf8": "^4.2.0",
-        "@smithy/uuid": "^1.1.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-stream": "^4.5.20",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3498,15 +3521,15 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.8.tgz",
-      "integrity": "sha512-FNT0xHS1c/CPN8upqbMFP83+ul5YgdisfCfkZ86Jh2NSmnqw/AJ6x5pEogVCTVvSm7j9MopRU89bmDelxuDMYw==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.12.tgz",
+      "integrity": "sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3584,15 +3607,15 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.9",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.9.tgz",
-      "integrity": "sha512-I4UhmcTYXBrct03rwzQX1Y/iqQlzVQaPxWjCjula++5EmWq9YGBrx6bbGqluGc1f0XEfhSkiY4jhLgbsJUMKRA==",
+      "version": "5.3.15",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.15.tgz",
+      "integrity": "sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/querystring-builder": "^4.2.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-base64": "^4.3.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/querystring-builder": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3615,14 +3638,14 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.8.tgz",
-      "integrity": "sha512-7ZIlPbmaDGxVoxErDZnuFG18WekhbA/g2/i97wGj+wUBeS6pcUeAym8u4BXh/75RXWhgIJhyC11hBzig6MljwA==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.12.tgz",
+      "integrity": "sha512-QhBYbGrbxTkZ43QoTPrK72DoYviDeg6YKDrHTMJbbC+A0sml3kSjzFtXP7BtbyJnXojLfTQldGdUR0RGD8dA3w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3644,12 +3667,12 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.8.tgz",
-      "integrity": "sha512-N9iozRybwAQ2dn9Fot9kI6/w9vos2oTXLhtK7ovGqwZjlOcxu6XhPlpLpC+INsxktqHinn5gS2DXDjDF2kG5sQ==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.12.tgz",
+      "integrity": "sha512-/4F1zb7Z8LOu1PalTdESFHR0RbPwHd3FcaG1sI3UEIriQTWakysgJr65lc1jj6QY5ye7aFsisajotH6UhWfm/g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3657,9 +3680,9 @@
       }
     },
     "node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3669,13 +3692,13 @@
       }
     },
     "node_modules/@smithy/md5-js": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.2.8.tgz",
-      "integrity": "sha512-oGMaLj4tVZzLi3itBa9TCswgMBr7k9b+qKYowQ6x1rTyTuO1IU2YHdHUa+891OsOH+wCsH7aTPRsTJO3RMQmjQ==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.2.12.tgz",
+      "integrity": "sha512-W/oIpHCpWU2+iAkfZYyGWE+qkpuf3vEXHLxQQDx9FPNZTTdnul0dZ2d/gUFrtQ5je1G2kp4cjG0/24YueG2LbQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3683,13 +3706,13 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.8.tgz",
-      "integrity": "sha512-RO0jeoaYAB1qBRhfVyq0pMgBoUK34YEJxVxyjOWYZiOKOq2yMZ4MnVXMZCUDenpozHue207+9P5ilTV1zeda0A==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.12.tgz",
+      "integrity": "sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3697,18 +3720,18 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.14",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.14.tgz",
-      "integrity": "sha512-FUFNE5KVeaY6U/GL0nzAAHkaCHzXLZcY1EhtQnsAqhD8Du13oPKtMB9/0WK4/LK6a/T5OZ24wPoSShff5iI6Ag==",
+      "version": "4.4.27",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.27.tgz",
+      "integrity": "sha512-T3TFfUgXQlpcg+UdzcAISdZpj4Z+XECZ/cefgA6wLBd6V4lRi0svN2hBouN/be9dXQ31X4sLWz3fAQDf+nt6BA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.0",
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/core": "^3.23.12",
+        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-middleware": "^4.2.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3716,19 +3739,19 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.4.31",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.31.tgz",
-      "integrity": "sha512-RXBzLpMkIrxBPe4C8OmEOHvS8aH9RUuCOH++Acb5jZDEblxDjyg6un72X9IcbrGTJoiUwmI7hLypNfuDACypbg==",
+      "version": "4.4.44",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.44.tgz",
+      "integrity": "sha512-Y1Rav7m5CFRPQyM4CI0koD/bXjyjJu3EQxZZhtLGD88WIrBrQ7kqXM96ncd6rYnojwOo/u9MXu57JrEvu/nLrA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/service-error-classification": "^4.2.8",
-        "@smithy/smithy-client": "^4.11.3",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-retry": "^4.2.8",
-        "@smithy/uuid": "^1.1.0",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/service-error-classification": "^4.2.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3736,13 +3759,14 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.9.tgz",
-      "integrity": "sha512-eMNiej0u/snzDvlqRGSN3Vl0ESn3838+nKyVfF2FKNXFbi4SERYT6PR392D39iczngbqqGG0Jl1DlCnp7tBbXQ==",
+      "version": "4.2.15",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.15.tgz",
+      "integrity": "sha512-ExYhcltZSli0pgAKOpQQe1DLFBLryeZ22605y/YS+mQpdNWekum9Ujb/jMKfJKgjtz1AZldtwA/wCYuKJgjjlg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
+        "@smithy/core": "^3.23.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3750,12 +3774,12 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.8.tgz",
-      "integrity": "sha512-w6LCfOviTYQjBctOKSwy6A8FIkQy7ICvglrZFl6Bw4FmcQ1Z420fUtIhxaUZZshRe0VCq4kvDiPiXrPZAe8oRA==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.12.tgz",
+      "integrity": "sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3763,14 +3787,14 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.8.tgz",
-      "integrity": "sha512-aFP1ai4lrbVlWjfpAfRSL8KFcnJQYfTl5QxLJXY32vghJrDuFyPZ6LtUL+JEGYiFRG1PfPLHLoxj107ulncLIg==",
+      "version": "4.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.12.tgz",
+      "integrity": "sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3778,15 +3802,15 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.4.10",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.10.tgz",
-      "integrity": "sha512-u4YeUwOWRZaHbWaebvrs3UhwQwj+2VNmcVCwXcYTvPIuVyM7Ex1ftAj+fdbG/P4AkBwLq/+SKn+ydOI4ZJE9PA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.0.tgz",
+      "integrity": "sha512-Rnq9vQWiR1+/I6NZZMNzJHV6pZYyEHt2ZnuV3MG8z2NNenC4i/8Kzttz7CjZiHSmsN5frhXhg17z3Zqjjhmz1A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/querystring-builder": "^4.2.8",
-        "@smithy/types": "^4.12.0",
+        "@smithy/abort-controller": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/querystring-builder": "^4.2.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3794,12 +3818,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.8.tgz",
-      "integrity": "sha512-EtCTbyIveCKeOXDSWSdze3k612yCPq1YbXsbqX3UHhkOSW8zKsM9NOJG5gTIya0vbY2DIaieG8pKo1rITHYL0w==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.12.tgz",
+      "integrity": "sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3807,12 +3831,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.8.tgz",
-      "integrity": "sha512-QNINVDhxpZ5QnP3aviNHQFlRogQZDfYlCkQT+7tJnErPQbDhysondEjhikuANxgMsZrkGeiAxXy4jguEGsDrWQ==",
+      "version": "5.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.12.tgz",
+      "integrity": "sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3820,13 +3844,13 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.8.tgz",
-      "integrity": "sha512-Xr83r31+DrE8CP3MqPgMJl+pQlLLmOfiEUnoyAlGzzJIrEsbKsPy1hqH0qySaQm4oWrCBlUqRt+idEgunKB+iw==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.12.tgz",
+      "integrity": "sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-uri-escape": "^4.2.0",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-uri-escape": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3834,12 +3858,12 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.8.tgz",
-      "integrity": "sha512-vUurovluVy50CUlazOiXkPq40KGvGWSdmusa3130MwrR1UNnNgKAlj58wlOe61XSHRpUfIIh6cE0zZ8mzKaDPA==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.12.tgz",
+      "integrity": "sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3847,24 +3871,24 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.8.tgz",
-      "integrity": "sha512-mZ5xddodpJhEt3RkCjbmUQuXUOaPNTkbMGR0bcS8FE0bJDLMZlhmpgrvPNCYglVw5rsYTpSnv19womw9WWXKQQ==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.12.tgz",
+      "integrity": "sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0"
+        "@smithy/types": "^4.13.1"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.3.tgz",
-      "integrity": "sha512-DfQjxXQnzC5UbCUPeC3Ie8u+rIWZTvuDPAGU/BxzrOGhRvgUanaP68kDZA+jaT3ZI+djOf+4dERGlm9mWfFDrg==",
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.7.tgz",
+      "integrity": "sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3872,18 +3896,18 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.8.tgz",
-      "integrity": "sha512-6A4vdGj7qKNRF16UIcO8HhHjKW27thsxYci+5r/uVRkdcBEkOEiY8OMPuydLX4QHSrJqGHPJzPRwwVTqbLZJhg==",
+      "version": "5.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.12.tgz",
+      "integrity": "sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-uri-escape": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3891,17 +3915,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.11.3.tgz",
-      "integrity": "sha512-Q7kY5sDau8OoE6Y9zJoRGgje8P4/UY0WzH8R2ok0PDh+iJ+ZnEKowhjEqYafVcubkbYxQVaqwm3iufktzhprGg==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.7.tgz",
+      "integrity": "sha512-q3gqnwml60G44FECaEEsdQMplYhDMZYCtYhMCzadCnRnnHIobZJjegmdoUo6ieLQlPUzvrMdIJUpx6DoPmzANQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.0",
-        "@smithy/middleware-endpoint": "^4.4.14",
-        "@smithy/middleware-stack": "^4.2.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-stream": "^4.5.12",
+        "@smithy/core": "^3.23.12",
+        "@smithy/middleware-endpoint": "^4.4.27",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-stream": "^4.5.20",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3909,9 +3933,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.12.0.tgz",
-      "integrity": "sha512-9YcuJVTOBDjg9LWo23Qp0lTQ3D7fQsQtwle0jVfpbUHy9qBwCEgKuVH4FqFB3VYu0nwdHKiEMA+oXz7oV8X1kw==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
+      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3921,13 +3945,13 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.8.tgz",
-      "integrity": "sha512-NQho9U68TGMEU639YkXnVMV3GEFFULmmaWdlu1E9qzyIePOHsoSnagTGSDv1Zi8DCNN6btxOSdgmy5E/hsZwhA==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.12.tgz",
+      "integrity": "sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.2.8",
-        "@smithy/types": "^4.12.0",
+        "@smithy/querystring-parser": "^4.2.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3935,13 +3959,13 @@
       }
     },
     "node_modules/@smithy/util-base64": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
-      "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3949,9 +3973,9 @@
       }
     },
     "node_modules/@smithy/util-body-length-browser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
-      "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3961,9 +3985,9 @@
       }
     },
     "node_modules/@smithy/util-body-length-node": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
-      "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3973,12 +3997,12 @@
       }
     },
     "node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/is-array-buffer": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3986,9 +4010,9 @@
       }
     },
     "node_modules/@smithy/util-config-provider": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
-      "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3998,14 +4022,14 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.30",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.30.tgz",
-      "integrity": "sha512-cMni0uVU27zxOiU8TuC8pQLC1pYeZ/xEMxvchSK/ILwleRd1ugobOcIRr5vXtcRqKd4aBLWlpeBoDPJJ91LQng==",
+      "version": "4.3.43",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.43.tgz",
+      "integrity": "sha512-Qd/0wCKMaXxev/z00TvNzGCH2jlKKKxXP1aDxB6oKwSQthe3Og2dMhSayGCnsma1bK/kQX1+X7SMP99t6FgiiQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/smithy-client": "^4.11.3",
-        "@smithy/types": "^4.12.0",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4013,17 +4037,17 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.33",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.33.tgz",
-      "integrity": "sha512-LEb2aq5F4oZUSzWBG7S53d4UytZSkOEJPXcBq/xbG2/TmK9EW5naUZ8lKu1BEyWMzdHIzEVN16M3k8oxDq+DJA==",
+      "version": "4.2.47",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.47.tgz",
+      "integrity": "sha512-qSRbYp1EQ7th+sPFuVcVO05AE0QH635hycdEXlpzIahqHHf2Fyd/Zl+8v0XYMJ3cgDVPa0lkMefU7oNUjAP+DQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/credential-provider-imds": "^4.2.8",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/smithy-client": "^4.11.3",
-        "@smithy/types": "^4.12.0",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4031,13 +4055,13 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.8.tgz",
-      "integrity": "sha512-8JaVTn3pBDkhZgHQ8R0epwWt+BqPSLCjdjXXusK1onwJlRuN69fbvSK66aIKKO7SwVFM6x2J2ox5X8pOaWcUEw==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.3.tgz",
+      "integrity": "sha512-VACQVe50j0HZPjpwWcjyT51KUQ4AnsvEaQ2lKHOSL4mNLD0G9BjEniQ+yCt1qqfKfiAHRAts26ud7hBjamrwig==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/types": "^4.12.0",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4045,9 +4069,9 @@
       }
     },
     "node_modules/@smithy/util-hex-encoding": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
-      "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4057,12 +4081,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.8.tgz",
-      "integrity": "sha512-PMqfeJxLcNPMDgvPbbLl/2Vpin+luxqTGPpW3NAQVLbRrFRzTa4rNAASYeIGjRV9Ytuhzny39SpyU04EQreF+A==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.12.tgz",
+      "integrity": "sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4070,13 +4094,13 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.8.tgz",
-      "integrity": "sha512-CfJqwvoRY0kTGe5AkQokpURNCT1u/MkRzMTASWMPPo2hNSnKtF1D45dQl3DE2LKLr4m+PW9mCeBMJr5mCAVThg==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.12.tgz",
+      "integrity": "sha512-1zopLDUEOwumjcHdJ1mwBHddubYF8GMQvstVCLC54Y46rqoHwlIU+8ZzUeaBcD+WCJHyDGSeZ2ml9YSe9aqcoQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.2.8",
-        "@smithy/types": "^4.12.0",
+        "@smithy/service-error-classification": "^4.2.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4084,18 +4108,18 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.5.12",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.12.tgz",
-      "integrity": "sha512-D8tgkrmhAX/UNeCZbqbEO3uqyghUnEmmoO9YEvRuwxjlkKKUE7FOgCJnqpTlQPe9MApdWPky58mNQQHbnCzoNg==",
+      "version": "4.5.20",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.20.tgz",
+      "integrity": "sha512-4yXLm5n/B5SRBR2p8cZ90Sbv4zL4NKsgxdzCzp/83cXw2KxLEumt5p+GAVyRNZgQOSrzXn9ARpO0lUe8XSlSDw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/node-http-handler": "^4.4.10",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4103,9 +4127,9 @@
       }
     },
     "node_modules/@smithy/util-uri-escape": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4115,12 +4139,12 @@
       }
     },
     "node_modules/@smithy/util-utf8": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-buffer-from": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4142,9 +4166,9 @@
       }
     },
     "node_modules/@smithy/uuid": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
-      "integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -6960,10 +6984,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-xml-parser": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.4.tgz",
-      "integrity": "sha512-EFd6afGmXlCx8H8WTZHhAoDaWaGyuIBoZJ2mknrNxug+aZKjkp0a0dlars9Izl+jF+7Gu1/5f/2h68cQpe0IiA==",
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
       "funding": [
         {
           "type": "github",
@@ -6972,7 +6996,24 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^2.1.0"
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.5.8",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
+      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.2.0",
+        "strnum": "^2.2.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -8956,6 +8997,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
+      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -9861,9 +9917,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
-      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
+      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "start": "next start",
     "lint": "eslint",
     "generate:feedback-tickets": "node scripts/generate_feedback_tickets.mjs",
+    "package:cohort-analysis-worker": "./scripts/deploy-cohort-analysis-worker.sh",
+    "deploy:cohort-analysis-worker": "./scripts/update-cohort-analysis-worker.sh",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.985.0",
     "@aws-sdk/client-s3": "^3.988.0",
+    "@aws-sdk/client-sqs": "^3.1016.0",
     "@aws-sdk/lib-dynamodb": "^3.985.0",
     "@aws-sdk/s3-request-presigner": "^3.988.0",
     "dotenv": "^16.5.0",

--- a/scripts/deploy-cohort-analysis-worker.sh
+++ b/scripts/deploy-cohort-analysis-worker.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKER_DIR="$ROOT_DIR/workers/cohort-analysis-worker"
+BUILD_DIR="$WORKER_DIR/.build"
+ZIP_PATH="$BUILD_DIR/cohort-analysis-worker.zip"
+
+mkdir -p "$BUILD_DIR"
+rm -f "$ZIP_PATH"
+
+pushd "$WORKER_DIR" >/dev/null
+npm install --omit=dev
+zip -rq "$ZIP_PATH" index.mjs package.json package-lock.json node_modules
+popd >/dev/null
+
+echo "$ZIP_PATH"

--- a/scripts/update-cohort-analysis-worker.sh
+++ b/scripts/update-cohort-analysis-worker.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FUNCTION_NAME="${1:-${COHORT_ANALYSIS_WORKER_FUNCTION_NAME:-}}"
+AWS_REGION_VALUE="${ENGAGE_AWS_REGION:-${AWS_REGION:-us-east-2}}"
+
+if [[ -z "$FUNCTION_NAME" ]]; then
+  echo "Set COHORT_ANALYSIS_WORKER_FUNCTION_NAME or pass the Lambda function name as the first argument." >&2
+  exit 1
+fi
+
+if ! command -v aws >/dev/null 2>&1; then
+  echo "aws CLI is required to update the cohort analysis worker." >&2
+  exit 1
+fi
+
+ZIP_PATH="$("$ROOT_DIR/scripts/deploy-cohort-analysis-worker.sh")"
+
+aws lambda update-function-code \
+  --function-name "$FUNCTION_NAME" \
+  --zip-file "fileb://$ZIP_PATH" \
+  --publish \
+  --region "$AWS_REGION_VALUE"
+
+aws lambda wait function-updated \
+  --function-name "$FUNCTION_NAME" \
+  --region "$AWS_REGION_VALUE"
+
+echo "Updated $FUNCTION_NAME in $AWS_REGION_VALUE using $ZIP_PATH"

--- a/workers/cohort-analysis-worker/.gitignore
+++ b/workers/cohort-analysis-worker/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.build/

--- a/workers/cohort-analysis-worker/index.mjs
+++ b/workers/cohort-analysis-worker/index.mjs
@@ -467,6 +467,7 @@ const validateMessage = (payload) => {
     classId,
     assignmentId,
     lessonNumber,
+    forceRefresh,
     student,
     totalStudents,
   } = payload;
@@ -487,6 +488,7 @@ const validateMessage = (payload) => {
     classId,
     assignmentId,
     lessonNumber: normalizeLessonNumber(lessonNumber),
+    forceRefresh: forceRefresh === true,
     totalStudents: Number(totalStudents ?? 1),
     student,
   };
@@ -495,7 +497,15 @@ const validateMessage = (payload) => {
 const processRecord = async (record) => {
   const startedAt = performance.now();
   const payload = validateMessage(JSON.parse(record.body ?? "{}"));
-  const { jobId, classId, assignmentId, lessonNumber, totalStudents, student } =
+  const {
+    jobId,
+    classId,
+    assignmentId,
+    lessonNumber,
+    forceRefresh,
+    totalStudents,
+    student,
+  } =
     payload;
 
   let source = "model";
@@ -515,7 +525,13 @@ const processRecord = async (record) => {
     const cacheReadStartedAt = performance.now();
     let cachedPlanJson = null;
     try {
-      cachedPlanJson = await getCachedPlanJson(classId, assignmentId, student.id);
+      if (!forceRefresh) {
+        cachedPlanJson = await getCachedPlanJson(
+          classId,
+          assignmentId,
+          student.id,
+        );
+      }
     } finally {
       cacheReadMs = elapsedMs(cacheReadStartedAt);
     }
@@ -609,6 +625,7 @@ const processRecord = async (record) => {
         classId,
         assignmentId,
         lessonNumber,
+        forceRefresh,
         studentId: student.id,
         source,
         timing,
@@ -656,6 +673,7 @@ const processRecord = async (record) => {
         classId: payload.classId,
         assignmentId: payload.assignmentId,
         lessonNumber: payload.lessonNumber,
+        forceRefresh: payload.forceRefresh,
         studentId: payload.student.id,
         error: message,
         timing,

--- a/workers/cohort-analysis-worker/index.mjs
+++ b/workers/cohort-analysis-worker/index.mjs
@@ -1,0 +1,450 @@
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  UpdateCommand,
+} from "@aws-sdk/lib-dynamodb";
+import OpenAI, { APIConnectionTimeoutError } from "openai";
+
+const STRATEGY_REQUEST_TIMEOUT_MS = 45_000;
+
+const buildPrompt = (student) => ({
+  system: `You are an education engagement planner.
+Return JSON only with keys: name, strategy, relevance, overallRecommendation, recommendationReason, summary, tldr, rationale, tactics, cadence, checks.
+The strategy must be exactly one of: cognitive conflict, analogy, experience bridging, engaged critiquing.
+The relevance field is an object with those four strategies as keys and integer scores from 0-100.
+Use the student's two-question quiz (concept understanding and past experience) to justify the recommendation.
+Make the recommendationReason reference the student by name and the assignment/topic.
+For recommendationReason and rationale, cite 2+ concrete details from the student's answers and connect them directly to the chosen strategy.`,
+  user: `Student name: ${student.name}
+Assignment: ${student.assignment ?? "Not provided"}
+
+Questionnaire answers:
+${JSON.stringify(student.answers ?? {}, null, 2)}
+
+Return a plan:
+- name: short label
+- strategy: one of [cognitive conflict, analogy, experience bridging, engaged critiquing]
+- relevance: scores 0-100 for each strategy
+- overallRecommendation: 1-2 sentences, teacher-facing
+- recommendationReason: 2-3 sentences explaining why this strategy fits ${student.name}; reference the assignment/topic and cite 2+ specific answer details
+- summary: 1 sentence
+- tldr: 8-14 words, teacher-facing
+- rationale: 3-5 sentences; reference the assignment/topic and include at least one concrete in-class example of how the teacher would use the strategy with ${student.name}
+- tactics: 3-5 bullets
+- cadence: short phrase
+- checks: 1-3 quick checks`,
+});
+
+const normalizeStrategy = (strategy) => String(strategy ?? "").trim().toLowerCase();
+
+const ensurePlanFields = (plan) => {
+  if (!plan.relevance || typeof plan.relevance !== "object") {
+    plan.relevance = {};
+  }
+
+  const keys = [
+    "cognitive conflict",
+    "analogy",
+    "experience bridging",
+    "engaged critiquing",
+  ];
+
+  keys.forEach((key) => {
+    if (typeof plan.relevance[key] !== "number") {
+      plan.relevance[key] = key === plan.strategy ? 100 : 0;
+    }
+  });
+
+  if (!plan.overallRecommendation) {
+    plan.overallRecommendation = plan.summary || "Provide a focused strategy.";
+  }
+
+  if (!plan.recommendationReason) {
+    plan.recommendationReason = plan.rationale || "Aligned to student responses.";
+  }
+
+  if (!plan.tldr) {
+    plan.tldr = plan.summary || "Use the recommended strategy.";
+  }
+
+  return plan;
+};
+
+const parseJson = (value) => {
+  if (!value) {
+    throw new Error("LLM returned empty response.");
+  }
+
+  return JSON.parse(value);
+};
+
+const isTimeoutError = (error) =>
+  error instanceof APIConnectionTimeoutError ||
+  (error instanceof Error &&
+    (error.constructor.name === "APIConnectionTimeoutError" ||
+      error.message === "Request timed out."));
+
+const elapsedMs = (startedAt) => Math.round(performance.now() - startedAt);
+
+const nowIso = () => new Date().toISOString();
+
+const requireEnv = (name) => {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required.`);
+  }
+  return value;
+};
+
+const tableName = requireEnv("DYNAMODB_TABLE");
+const region = process.env.AWS_REGION ?? process.env.AWS_DEFAULT_REGION ?? "us-east-2";
+
+const dynamo = DynamoDBDocumentClient.from(new DynamoDBClient({ region }), {
+  marshallOptions: { removeUndefinedValues: true },
+});
+
+const openai = new OpenAI({
+  apiKey: requireEnv("OPENAI_API_KEY"),
+  timeout: STRATEGY_REQUEST_TIMEOUT_MS,
+  maxRetries: 0,
+});
+
+const getCachedPlanJson = async (classId, assignmentId, studentId) => {
+  const result = await dynamo.send(
+    new GetCommand({
+      TableName: tableName,
+      Key: {
+        class_id: `CLASS#${classId}`,
+        record_id: `PLAN#ASSIGN#${assignmentId}#STUDENT#${studentId}#LATEST`,
+      },
+    }),
+  );
+
+  return result.Item?.plan_json ?? null;
+};
+
+const upsertCachedPlanJson = async (classId, assignmentId, studentId, planJson) => {
+  await dynamo.send(
+    new PutCommand({
+      TableName: tableName,
+      Item: {
+        class_id: `CLASS#${classId}`,
+        record_id: `PLAN#ASSIGN#${assignmentId}#STUDENT#${studentId}#LATEST`,
+        record_type: "plan_cache",
+        assignment_id: assignmentId,
+        student_id: `STUDENT#${studentId}`,
+        student_record_id: `PLAN#ASSIGN#${assignmentId}#LATEST`,
+        plan_json: planJson,
+        updated_at: nowIso(),
+      },
+    }),
+  );
+};
+
+const jobPk = (jobId) => `JOB#${jobId}`;
+
+const updateJobMeta = async ({
+  jobId,
+  classId,
+  assignmentId,
+  totalStudents,
+  completedDelta,
+  failedDelta,
+}) => {
+  const timestamp = nowIso();
+  const result = await dynamo.send(
+    new UpdateCommand({
+      TableName: tableName,
+      Key: {
+        class_id: jobPk(jobId),
+        record_id: "META",
+      },
+      UpdateExpression: `SET record_type = :recordType,
+          source_class_id = :classId,
+          source_assignment_id = :assignmentId,
+          total_students = if_not_exists(total_students, :totalStudents),
+          created_at = if_not_exists(created_at, :createdAt),
+          updated_at = :updatedAt
+        ADD processed_students :processedDelta,
+          completed_students :completedDelta,
+          failed_students :failedDelta`,
+      ExpressionAttributeValues: {
+        ":recordType": "cohort_job",
+        ":classId": classId,
+        ":assignmentId": assignmentId,
+        ":totalStudents": totalStudents,
+        ":createdAt": timestamp,
+        ":updatedAt": timestamp,
+        ":processedDelta": 1,
+        ":completedDelta": completedDelta,
+        ":failedDelta": failedDelta,
+      },
+      ReturnValues: "ALL_NEW",
+    }),
+  );
+
+  const attributes = result.Attributes ?? {};
+  const processedStudents = Number(attributes.processed_students ?? 0);
+  const total = Number(attributes.total_students ?? totalStudents);
+  const failedStudents = Number(attributes.failed_students ?? 0);
+
+  if (processedStudents >= total && total > 0) {
+    await dynamo.send(
+      new UpdateCommand({
+        TableName: tableName,
+        Key: {
+          class_id: jobPk(jobId),
+          record_id: "META",
+        },
+        UpdateExpression: "SET #status = :status, updated_at = :updatedAt",
+        ExpressionAttributeNames: {
+          "#status": "status",
+        },
+        ExpressionAttributeValues: {
+          ":status": failedStudents > 0 ? "completed_with_errors" : "completed",
+          ":updatedAt": nowIso(),
+        },
+      }),
+    );
+  } else {
+    await dynamo.send(
+      new UpdateCommand({
+        TableName: tableName,
+        Key: {
+          class_id: jobPk(jobId),
+          record_id: "META",
+        },
+        UpdateExpression: "SET #status = :status, updated_at = :updatedAt",
+        ExpressionAttributeNames: {
+          "#status": "status",
+        },
+        ExpressionAttributeValues: {
+          ":status": "running",
+          ":updatedAt": nowIso(),
+        },
+      }),
+    );
+  }
+};
+
+const putStudentResult = async ({
+  jobId,
+  classId,
+  assignmentId,
+  student,
+  status,
+  plan,
+  source,
+  timing,
+  error,
+}) => {
+  await dynamo.send(
+    new PutCommand({
+      TableName: tableName,
+      Item: {
+        class_id: jobPk(jobId),
+        record_id: `STUDENT#${student.id}`,
+        record_type: "cohort_job_student",
+        source_class_id: classId,
+        source_assignment_id: assignmentId,
+        student_id: student.id,
+        student_name: student.name,
+        status,
+        source: source ?? null,
+        plan_json: plan ? JSON.stringify(plan) : undefined,
+        timing,
+        error: error ?? undefined,
+        updated_at: nowIso(),
+      },
+    }),
+  );
+};
+
+const validateMessage = (payload) => {
+  if (!payload || typeof payload !== "object") {
+    throw new Error("Message body must be an object.");
+  }
+
+  const { jobId, classId, assignmentId, student, totalStudents } = payload;
+  if (!jobId || !classId || !assignmentId) {
+    throw new Error("jobId, classId, and assignmentId are required.");
+  }
+
+  if (!student || typeof student !== "object") {
+    throw new Error("student is required.");
+  }
+
+  if (!student.id || !student.name) {
+    throw new Error("student.id and student.name are required.");
+  }
+
+  return {
+    jobId,
+    classId,
+    assignmentId,
+    totalStudents: Number(totalStudents ?? 1),
+    student,
+  };
+};
+
+const processRecord = async (record) => {
+  const startedAt = performance.now();
+  const payload = validateMessage(JSON.parse(record.body ?? "{}"));
+  const { jobId, classId, assignmentId, totalStudents, student } = payload;
+
+  let source = "model";
+  let cacheReadMs = 0;
+  let modelMs = 0;
+  let cacheWriteMs = 0;
+
+  try {
+    const cacheReadStartedAt = performance.now();
+    let cachedPlanJson = null;
+    try {
+      cachedPlanJson = await getCachedPlanJson(classId, assignmentId, student.id);
+    } finally {
+      cacheReadMs = elapsedMs(cacheReadStartedAt);
+    }
+
+    let plan;
+    if (cachedPlanJson) {
+      source = "cache";
+      const parsed = JSON.parse(cachedPlanJson);
+      parsed.strategy = normalizeStrategy(parsed.strategy);
+      plan = ensurePlanFields(parsed);
+    } else {
+      const prompt = buildPrompt(student);
+      const completion = await (async () => {
+        const modelStartedAt = performance.now();
+        try {
+          return await openai.chat.completions.create({
+            model: process.env.OPENAI_MODEL ?? "gpt-5-nano",
+            response_format: { type: "json_object" },
+            messages: [
+              { role: "system", content: prompt.system },
+              { role: "user", content: prompt.user },
+            ],
+          });
+        } finally {
+          modelMs = elapsedMs(modelStartedAt);
+        }
+      })();
+
+      const parsed = parseJson(completion.choices[0]?.message?.content);
+      parsed.strategy = normalizeStrategy(parsed.strategy);
+      plan = ensurePlanFields(parsed);
+
+      const cacheWriteStartedAt = performance.now();
+      try {
+        await upsertCachedPlanJson(
+          classId,
+          assignmentId,
+          student.id,
+          JSON.stringify(plan),
+        );
+      } finally {
+        cacheWriteMs = elapsedMs(cacheWriteStartedAt);
+      }
+    }
+
+    const timing = {
+      cacheReadMs,
+      modelMs,
+      cacheWriteMs,
+      totalMs: elapsedMs(startedAt),
+      timedOut: false,
+    };
+
+    await putStudentResult({
+      jobId,
+      classId,
+      assignmentId,
+      student,
+      status: "completed",
+      source,
+      plan,
+      timing,
+    });
+
+    await updateJobMeta({
+      jobId,
+      classId,
+      assignmentId,
+      totalStudents,
+      completedDelta: 1,
+      failedDelta: 0,
+    });
+
+    console.info(
+      "cohort-analysis-worker success",
+      JSON.stringify({
+        jobId,
+        classId,
+        assignmentId,
+        studentId: student.id,
+        source,
+        timing,
+      }),
+    );
+  } catch (error) {
+    const timing = {
+      cacheReadMs,
+      modelMs,
+      cacheWriteMs,
+      totalMs: elapsedMs(startedAt),
+      timedOut: isTimeoutError(error),
+    };
+    const message =
+      isTimeoutError(error)
+        ? "Strategy generation timed out before the model returned."
+        : error instanceof Error
+          ? error.message
+          : "Failed to analyze student.";
+
+    await putStudentResult({
+      jobId: payload.jobId,
+      classId: payload.classId,
+      assignmentId: payload.assignmentId,
+      student: payload.student,
+      status: "failed",
+      source,
+      timing,
+      error: message,
+    });
+
+    await updateJobMeta({
+      jobId: payload.jobId,
+      classId: payload.classId,
+      assignmentId: payload.assignmentId,
+      totalStudents: payload.totalStudents,
+      completedDelta: 0,
+      failedDelta: 1,
+    });
+
+    console.error(
+      "cohort-analysis-worker failure",
+      JSON.stringify({
+        jobId: payload.jobId,
+        classId: payload.classId,
+        assignmentId: payload.assignmentId,
+        studentId: payload.student.id,
+        error: message,
+        timing,
+      }),
+    );
+
+    throw error;
+  }
+};
+
+export const handler = async (event) => {
+  for (const record of event.Records ?? []) {
+    await processRecord(record);
+  }
+
+  return {
+    batchItemFailures: [],
+  };
+};

--- a/workers/cohort-analysis-worker/package-lock.json
+++ b/workers/cohort-analysis-worker/package-lock.json
@@ -1,0 +1,1412 @@
+{
+  "name": "cohort-analysis-worker",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cohort-analysis-worker",
+      "version": "0.1.0",
+      "dependencies": {
+        "@aws-sdk/client-dynamodb": "^3.985.0",
+        "@aws-sdk/lib-dynamodb": "^3.985.0",
+        "openai": "^6.17.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb": {
+      "version": "3.1016.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1016.0.tgz",
+      "integrity": "sha512-Owy1wQEJuLQ1WAc7QUQQ+3vSPWY6/JWBsPEDn9GM2F3+vDAtPL/HrZlfpY2BMeo6lxhm3/PfTg9wGy/TmK6buw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/credential-provider-node": "^3.972.25",
+        "@aws-sdk/dynamodb-codec": "^3.972.25",
+        "@aws-sdk/middleware-endpoint-discovery": "^3.972.8",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+        "@aws-sdk/middleware-user-agent": "^3.972.25",
+        "@aws-sdk/region-config-resolver": "^3.972.9",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.11",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/core": "^3.23.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.27",
+        "@smithy/middleware-retry": "^4.4.44",
+        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.43",
+        "@smithy/util-defaults-mode-node": "^4.2.47",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-waiter": "^4.2.13",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.973.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.24.tgz",
+      "integrity": "sha512-vvf82RYQu2GidWAuQq+uIzaPz9V0gSCXVqdVzRosgl5rXcspXOpSD3wFreGGW6AYymPr97Z69kjVnLePBxloDw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/xml-builder": "^3.972.15",
+        "@smithy/core": "^3.23.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/signature-v4": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.22.tgz",
+      "integrity": "sha512-cXp0VTDWT76p3hyK5D51yIKEfpf6/zsUvMfaB8CkyqadJxMQ8SbEeVroregmDlZbtG31wkj9ei0WnftmieggLg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.24.tgz",
+      "integrity": "sha512-h694K7+tRuepSRJr09wTvQfaEnjzsKZ5s7fbESrVds02GT/QzViJ94/HCNwM7bUfFxqpPXHxulZfL6Cou0dwPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-stream": "^4.5.20",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.24.tgz",
+      "integrity": "sha512-O46fFmv0RDFWiWEA9/e6oW92BnsyAXuEgTTasxHligjn2RCr9L/DK773m/NoFaL3ZdNAUz8WxgxunleMnHAkeQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/credential-provider-env": "^3.972.22",
+        "@aws-sdk/credential-provider-http": "^3.972.24",
+        "@aws-sdk/credential-provider-login": "^3.972.24",
+        "@aws-sdk/credential-provider-process": "^3.972.22",
+        "@aws-sdk/credential-provider-sso": "^3.972.24",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.24",
+        "@aws-sdk/nested-clients": "^3.996.14",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.24.tgz",
+      "integrity": "sha512-sIk8oa6AzDoUhxsR11svZESqvzGuXesw62Rl2oW6wguZx8i9cdGCvkFg+h5K7iucUZP8wyWibUbJMc+J66cu5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/nested-clients": "^3.996.14",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.25.tgz",
+      "integrity": "sha512-m7dR0Dsva2P+VUpL+VkC0WwiDby5pgmWXkRVDB5rlwv0jXJrQJf7YMtCoM8Wjk0H9jPeCYOxOXXcIgp/qp5Alg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.22",
+        "@aws-sdk/credential-provider-http": "^3.972.24",
+        "@aws-sdk/credential-provider-ini": "^3.972.24",
+        "@aws-sdk/credential-provider-process": "^3.972.22",
+        "@aws-sdk/credential-provider-sso": "^3.972.24",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.24",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.22.tgz",
+      "integrity": "sha512-Os32s8/4gTZjBk5BtoS/cuTILaj+K72d0dVG7TCJX/fC4598cxwLDmf1AEHEpER5oL3K//yETjvFaz0V8oO5Xw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.24.tgz",
+      "integrity": "sha512-PaFv7snEfypU2yXkpvfyWgddEbDLtgVe51wdZlinhc2doubBjUzJZZpgwuF2Jenl1FBydMhNpMjD6SBUM3qdSA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/nested-clients": "^3.996.14",
+        "@aws-sdk/token-providers": "3.1015.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.24.tgz",
+      "integrity": "sha512-J6H4R1nvr3uBTqD/EeIPAskrBtET4WFfNhpFySr2xW7bVZOXpQfPjrLSIx65jcNjBmLXzWq8QFLdVoGxiGG/SA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/nested-clients": "^3.996.14",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/dynamodb-codec": {
+      "version": "3.972.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.972.25.tgz",
+      "integrity": "sha512-AfkNIk19MOeGXfRyznRMZNOTUt79HU2pl7GP606oUIGELmS495xfvGDGp9nGYbOPxWhXfM7/s51V8+lvmCEwVg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.24",
+        "@smithy/core": "^3.23.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/endpoint-cache": {
+      "version": "3.972.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.4.tgz",
+      "integrity": "sha512-GdASDnWanLnHxKK0hqV97xz23QmfA/C8yGe0PiuEmWiHSe+x+x+mFEj4sXqx9IbfyPncWz8f4EhNwBSG9cgYCg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mnemonist": "0.38.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/lib-dynamodb": {
+      "version": "3.1016.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.1016.0.tgz",
+      "integrity": "sha512-vyhNmcF30CpErFMM5z86NUcQ8V64eSbSLnLGbkgE2oYqWFNctZwPJF/FWUOV6SEAEEW35oK3QvK2K0woMdDflw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/util-dynamodb": "^3.996.2",
+        "@smithy/core": "^3.23.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1016.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.8.tgz",
+      "integrity": "sha512-S0oXx1QbSpMDBMJn4P0hOxW8ieGAdRT+G9NbL+ESWkkoCGf9D++fKYD2fyBGtIy88OrP7wgECpXgGLAcGpIj0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/endpoint-cache": "^3.972.4",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.8.tgz",
+      "integrity": "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.8.tgz",
+      "integrity": "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.8.tgz",
+      "integrity": "sha512-BnnvYs2ZEpdlmZ2PNlV2ZyQ8j8AEkMTjN79y/YA475ER1ByFYrkVR85qmhni8oeTaJcDqbx364wDpitDAA/wCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.972.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.25.tgz",
+      "integrity": "sha512-QxiMPofvOt8SwSynTOmuZfvvPM1S9QfkESBxB22NMHTRXCJhR5BygLl8IXfC4jELiisQgwsgUby21GtXfX3f/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@smithy/core": "^3.23.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-retry": "^4.2.12",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.996.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.14.tgz",
+      "integrity": "sha512-fSESKvh1VbfjtV3QMnRkCPZWkUbQof6T/DOpiLp33yP2wA+rbwwnZeG3XT3Ekljgw2I8X4XaQPnw+zSR8yxJ5Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+        "@aws-sdk/middleware-user-agent": "^3.972.25",
+        "@aws-sdk/region-config-resolver": "^3.972.9",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.11",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/core": "^3.23.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.27",
+        "@smithy/middleware-retry": "^4.4.44",
+        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.43",
+        "@smithy/util-defaults-mode-node": "^4.2.47",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.9.tgz",
+      "integrity": "sha512-eQ+dFU05ZRC/lC2XpYlYSPlXtX3VT8sn5toxN2Fv7EXlMoA2p9V7vUBKqHunfD4TRLpxUq8Y8Ol/nCqiv327Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1015.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1015.0.tgz",
+      "integrity": "sha512-3OSD4y110nisRhHzFOjoEeHU4GQL4KpzkX9PxzWaiZe0Yg2+thZKM0Pn9DjYwezH5JYfh/K++xK/SE0IHGrmCQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/nested-clients": "^3.996.14",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
+      "integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-dynamodb": {
+      "version": "3.996.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.996.2.tgz",
+      "integrity": "sha512-ddpwaZmjBzcApYN7lgtAXjk+u+GO8fiPsxzuc59UqP+zqdxI1gsenPvkyiHiF9LnYnyRGijz6oN2JylnN561qQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1003.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.996.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
+      "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-endpoints": "^3.3.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.8.tgz",
+      "integrity": "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.973.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.11.tgz",
+      "integrity": "sha512-1qdXbXo2s5MMLpUvw00284LsbhtlQ4ul7Zzdn5n+7p4WVgCMLqhxImpHIrjSoc72E/fyc4Wq8dLtUld2Gsh+lA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "^3.972.25",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.15.tgz",
+      "integrity": "sha512-PxMRlCFNiQnke9YR29vjFQwz4jq+6Q04rOVFeTDR2K7Qpv9h9FOWOxG+zJjageimYbWqE3bTuLjmryWHAWbvaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "fast-xml-parser": "5.5.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/abort-controller": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.12.tgz",
+      "integrity": "sha512-xolrFw6b+2iYGl6EcOL7IJY71vvyZ0DJ3mcKtpykqPe2uscwtzDZJa1uVQXyP7w9Dd+kGwYnPbMsJrGISKiY/Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.4.13",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.13.tgz",
+      "integrity": "sha512-iIzMC5NmOUP6WL6o8iPBjFhUhBZ9pPjpUpQYWMUFQqKyXXzOftbfK8zcQCz/jFV1Psmf05BK5ypx4K2r4Tnwdg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.23.12",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.12.tgz",
+      "integrity": "sha512-o9VycsYNtgC+Dy3I0yrwCqv9CWicDnke0L7EVOrZtJpjb2t0EjaEofmMrYc0T1Kn3yk32zm6cspxF9u9Bj7e5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-stream": "^4.5.20",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.12.tgz",
+      "integrity": "sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.3.15",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.15.tgz",
+      "integrity": "sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/querystring-builder": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.12.tgz",
+      "integrity": "sha512-QhBYbGrbxTkZ43QoTPrK72DoYviDeg6YKDrHTMJbbC+A0sml3kSjzFtXP7BtbyJnXojLfTQldGdUR0RGD8dA3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.12.tgz",
+      "integrity": "sha512-/4F1zb7Z8LOu1PalTdESFHR0RbPwHd3FcaG1sI3UEIriQTWakysgJr65lc1jj6QY5ye7aFsisajotH6UhWfm/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.12.tgz",
+      "integrity": "sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.4.27",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.27.tgz",
+      "integrity": "sha512-T3TFfUgXQlpcg+UdzcAISdZpj4Z+XECZ/cefgA6wLBd6V4lRi0svN2hBouN/be9dXQ31X4sLWz3fAQDf+nt6BA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.12",
+        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-middleware": "^4.2.12",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.4.44",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.44.tgz",
+      "integrity": "sha512-Y1Rav7m5CFRPQyM4CI0koD/bXjyjJu3EQxZZhtLGD88WIrBrQ7kqXM96ncd6rYnojwOo/u9MXu57JrEvu/nLrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/service-error-classification": "^4.2.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.2.15",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.15.tgz",
+      "integrity": "sha512-ExYhcltZSli0pgAKOpQQe1DLFBLryeZ22605y/YS+mQpdNWekum9Ujb/jMKfJKgjtz1AZldtwA/wCYuKJgjjlg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.12.tgz",
+      "integrity": "sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.12.tgz",
+      "integrity": "sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.0.tgz",
+      "integrity": "sha512-Rnq9vQWiR1+/I6NZZMNzJHV6pZYyEHt2ZnuV3MG8z2NNenC4i/8Kzttz7CjZiHSmsN5frhXhg17z3Zqjjhmz1A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/querystring-builder": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.12.tgz",
+      "integrity": "sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.12.tgz",
+      "integrity": "sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.12.tgz",
+      "integrity": "sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.12.tgz",
+      "integrity": "sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.12.tgz",
+      "integrity": "sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.7.tgz",
+      "integrity": "sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.12.tgz",
+      "integrity": "sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.7.tgz",
+      "integrity": "sha512-q3gqnwml60G44FECaEEsdQMplYhDMZYCtYhMCzadCnRnnHIobZJjegmdoUo6ieLQlPUzvrMdIJUpx6DoPmzANQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.12",
+        "@smithy/middleware-endpoint": "^4.4.27",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-stream": "^4.5.20",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
+      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.12.tgz",
+      "integrity": "sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.3.43",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.43.tgz",
+      "integrity": "sha512-Qd/0wCKMaXxev/z00TvNzGCH2jlKKKxXP1aDxB6oKwSQthe3Og2dMhSayGCnsma1bK/kQX1+X7SMP99t6FgiiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.2.47",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.47.tgz",
+      "integrity": "sha512-qSRbYp1EQ7th+sPFuVcVO05AE0QH635hycdEXlpzIahqHHf2Fyd/Zl+8v0XYMJ3cgDVPa0lkMefU7oNUjAP+DQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.3.tgz",
+      "integrity": "sha512-VACQVe50j0HZPjpwWcjyT51KUQ4AnsvEaQ2lKHOSL4mNLD0G9BjEniQ+yCt1qqfKfiAHRAts26ud7hBjamrwig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.12.tgz",
+      "integrity": "sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.12.tgz",
+      "integrity": "sha512-1zopLDUEOwumjcHdJ1mwBHddubYF8GMQvstVCLC54Y46rqoHwlIU+8ZzUeaBcD+WCJHyDGSeZ2ml9YSe9aqcoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "4.5.20",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.20.tgz",
+      "integrity": "sha512-4yXLm5n/B5SRBR2p8cZ90Sbv4zL4NKsgxdzCzp/83cXw2KxLEumt5p+GAVyRNZgQOSrzXn9ARpO0lUe8XSlSDw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.13.tgz",
+      "integrity": "sha512-2zdZ9DTHngRtcYxJK1GUDxruNr53kv5W2Lupe0LMU+Imr6ohQg8M2T14MNkj1Y0wS3FFwpgpGQyvuaMF7CiTmQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/uuid": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.5.8",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
+      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.2.0",
+        "strnum": "^2.2.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/mnemonist": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "license": "MIT",
+      "dependencies": {
+        "obliterator": "^1.6.1"
+      }
+    },
+    "node_modules/obliterator": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
+      "license": "MIT"
+    },
+    "node_modules/openai": {
+      "version": "6.32.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.32.0.tgz",
+      "integrity": "sha512-j3k+BjydAf8yQlcOI7WUQMQTbbF5GEIMAE2iZYCOzwwB3S2pCheaWYp+XZRNAch4jWVc52PMDGRRjutao3lLCg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
+      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
+      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    }
+  }
+}

--- a/workers/cohort-analysis-worker/package.json
+++ b/workers/cohort-analysis-worker/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "cohort-analysis-worker",
+  "private": true,
+  "type": "module",
+  "version": "0.1.0",
+  "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.985.0",
+    "@aws-sdk/lib-dynamodb": "^3.985.0",
+    "openai": "^6.17.0"
+  }
+}


### PR DESCRIPTION
## Summary
- queue uncached cohort analysis requests through SQS and persist per-job progress/results
- add strategy-job start/status endpoints plus TeacherView polling with synchronous fallback
- add the cohort-analysis worker, deployment script, and API coverage for the new job flow

## Testing
- npm test
- npm run build