### PR TITLE
Wire lesson objectives into generation flow

### DIFF
--- a/__tests__/api/lessons.test.ts
+++ b/__tests__/api/lessons.test.ts
@@ -8,6 +8,7 @@ describe("GET /api/lessons/[lessonNumber]", () => {
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data.lesson_number).toBe(1);
+    expect(data.learning_objective).toBeTruthy();
     expect(data.quiz_items.length).toBeGreaterThan(0);
   });
 

--- a/__tests__/api/strategy-batch.test.ts
+++ b/__tests__/api/strategy-batch.test.ts
@@ -56,6 +56,7 @@ const buildRequest = (students: Array<Record<string, unknown>>) =>
     body: JSON.stringify({
       classId: "class-1",
       assignmentId: "assignment-1",
+      lessonNumber: 1,
       students,
     }),
   });
@@ -100,8 +101,8 @@ describe("POST /api/strategy-batch", () => {
       .mockRejectedValueOnce(new MockAPIConnectionTimeoutError());
 
     const res = await POST(buildRequest([
-      { id: "student-1", name: "Jon", answers: { q1: "A", q2: "B" } },
-      { id: "student-2", name: "David", answers: { q1: "C", q2: "D" } },
+      { id: "student-1", name: "Jon", answers: { L1_Q1: "A", L1_Q1_confidence: "B" } },
+      { id: "student-2", name: "David", answers: { L1_Q1: "C", L1_Q1_confidence: "D" } },
     ]));
 
     expect(res.status).toBe(504);
@@ -127,8 +128,8 @@ describe("POST /api/strategy-batch", () => {
       .mockRejectedValueOnce(new MockAPIConnectionTimeoutError());
 
     const res = await POST(buildRequest([
-      { id: "student-1", name: "Ava", answers: { q1: "A", q2: "B" } },
-      { id: "student-2", name: "Jon", answers: { q1: "C", q2: "D" } },
+      { id: "student-1", name: "Ava", answers: { L1_Q1: "A", L1_Q1_confidence: "B" } },
+      { id: "student-2", name: "Jon", answers: { L1_Q1: "C", L1_Q1_confidence: "D" } },
     ]));
 
     expect(res.status).toBe(200);
@@ -161,10 +162,10 @@ describe("POST /api/strategy-batch", () => {
     );
 
     const requestPromise = POST(buildRequest([
-      { id: "student-1", name: "Ava", answers: { q1: "A", q2: "B" } },
-      { id: "student-2", name: "Jon", answers: { q1: "C", q2: "D" } },
-      { id: "student-3", name: "David", answers: { q1: "E", q2: "F" } },
-      { id: "student-4", name: "Mia", answers: { q1: "G", q2: "H" } },
+      { id: "student-1", name: "Ava", answers: { L1_Q1: "A", L1_Q1_confidence: "B" } },
+      { id: "student-2", name: "Jon", answers: { L1_Q1: "C", L1_Q1_confidence: "D" } },
+      { id: "student-3", name: "David", answers: { L1_Q1: "A", L1_Q1_confidence: "C" } },
+      { id: "student-4", name: "Mia", answers: { L1_Q1: "B", L1_Q1_confidence: "A" } },
     ]));
 
     await new Promise((resolve) => setTimeout(resolve, 0));
@@ -180,5 +181,39 @@ describe("POST /api/strategy-batch", () => {
     const data = await res.json();
     expect(data.results).toHaveLength(4);
     expect(data.errors).toEqual([]);
+  });
+
+  it("includes the lesson objective and resolved quiz evidence in the prompt", async () => {
+    createCompletion.mockResolvedValueOnce(buildCompletion("cognitive conflict"));
+
+    const res = await POST(buildRequest([
+      {
+        id: "student-1",
+        name: "Ava",
+        answers: {
+          L1_Q1: "D",
+          L1_Q1_confidence: "B",
+        },
+      },
+    ]));
+
+    expect(res.status).toBe(200);
+    expect(createCompletion).toHaveBeenCalledTimes(1);
+    const firstCall = createCompletion.mock.calls[0]?.[0];
+    const userPrompt = firstCall?.messages?.[1]?.content as string;
+
+    expect(userPrompt).toContain("Lesson objective:");
+    expect(userPrompt).toContain(
+      "Students will construct temporal visual models and causal explanations",
+    );
+    expect(userPrompt).toContain(
+      "A phone drops onto a soft pillow. The phone looks the same afterward.",
+    );
+    expect(userPrompt).toContain(
+      "The force was weak because nothing was damaged.",
+    );
+    expect(userPrompt).toContain(
+      "If nothing looks damaged after the collision, the force must have been weak.",
+    );
   });
 });

--- a/__tests__/api/student-answers.test.ts
+++ b/__tests__/api/student-answers.test.ts
@@ -110,4 +110,24 @@ describe("GET /api/student-answers", () => {
     const data = await res.json();
     expect(data.answer.student_id).toBe("s1");
   });
+
+  it("should filter answers by lesson number when provided", async () => {
+    await POST(new Request("http://localhost:3000/api/student-answers", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ classId: "c1", assignmentId: "a1", studentId: "s1", studentName: "Alice", lessonNumber: 1, answers: { Q1: "A" } }),
+    }));
+    await POST(new Request("http://localhost:3000/api/student-answers", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ classId: "c1", assignmentId: "a1", studentId: "s2", studentName: "Bob", lessonNumber: 2, answers: { Q1: "B" } }),
+    }));
+
+    const req = new Request("http://localhost:3000/api/student-answers?classId=c1&assignmentId=a1&lessonNumber=1");
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.answers).toHaveLength(1);
+    expect(data.answers[0].student_id).toBe("s1");
+  });
 });

--- a/__tests__/lib/lesson-context.test.ts
+++ b/__tests__/lib/lesson-context.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getLessonGenerationContext,
+  getStrategyContext,
+  resolveQuizEvidence,
+} from "@/lib/lesson-context";
+
+describe("getLessonGenerationContext", () => {
+  it("returns the lesson objective context for a lesson", () => {
+    expect(getLessonGenerationContext(1)).toEqual({
+      lessonNumber: 1,
+      lessonTitle: "Lesson 1",
+      learningObjective:
+        "Students will construct temporal visual models and causal explanations to link unobservable energy transfer and interaction forces to the observable macroscopic changes in an object's shape and motion before and after an impact.",
+    });
+  });
+});
+
+describe("getStrategyContext", () => {
+  it("returns the human-friendly label and description for a strategy", () => {
+    expect(getStrategyContext("cognitive conflict")).toEqual({
+      id: "cognitive conflict",
+      label: "Cognitive Conflict",
+      description:
+        "Challenges a student’s current belief with surprising evidence so they rethink the concept.",
+    });
+  });
+});
+
+describe("resolveQuizEvidence", () => {
+  it("resolves selected answers, confidence, correctness, and misconception text", () => {
+    const evidence = resolveQuizEvidence(1, {
+      L1_Q1: "D",
+      L1_Q1_confidence: "B",
+    });
+
+    expect(evidence[0]).toEqual({
+      itemId: "L1_Q1",
+      questionNumber: 1,
+      stem: "A phone drops onto a soft pillow. The phone looks the same afterward. Which statement best describes the collision?",
+      selectedOption: "D",
+      selectedText: "The force was weak because nothing was damaged.",
+      correctOption: "C",
+      correctText: "The phone and pillow pushed on each other.",
+      isCorrect: false,
+      confidenceOption: "B",
+      confidenceText: "Somewhat confident",
+      misconceptionCode: "a",
+      misconceptionText:
+        "If nothing looks damaged after the collision, the force must have been weak.",
+    });
+  });
+});

--- a/__tests__/lib/quiz-data.test.ts
+++ b/__tests__/lib/quiz-data.test.ts
@@ -24,7 +24,7 @@ describe("getAllLessons", () => {
   it("each lesson should have misconceptions", () => {
     const lessons = getAllLessons();
     for (const lesson of lessons) {
-      expect(lesson.misconceptions.length).toBeGreaterThan(0);
+      expect(Object.keys(lesson.misconceptions).length).toBeGreaterThan(0);
     }
   });
 
@@ -69,6 +69,13 @@ describe("getLessonQuizItems", () => {
       expect(item.options).toHaveProperty("B");
       expect(item.options).toHaveProperty("C");
       expect(item.options).toHaveProperty("D");
+    }
+  });
+
+  it("each lesson should have a learning objective", () => {
+    const lessons = getAllLessons();
+    for (const lesson of lessons) {
+      expect(lesson.learning_objective).toBeTruthy();
     }
   });
 

--- a/app/api/engagement-content/route.ts
+++ b/app/api/engagement-content/route.ts
@@ -1,22 +1,13 @@
 import OpenAI from "openai";
 import { NextResponse } from "next/server";
+
+import {
+  getLessonGenerationContext,
+  getStrategyContext,
+  type LessonGenerationContext,
+  type StrategyContext,
+} from "@/lib/lesson-context";
 import type { ContentItem, TextMode } from "@/lib/types";
-
-type Answers = Record<string, string | undefined>;
-
-type Plan = {
-  name: string;
-  strategy: string;
-  relevance: Record<string, number>;
-  overallRecommendation: string;
-  recommendationReason: string;
-  summary: string;
-  tldr: string;
-  rationale: string;
-  tactics: string[];
-  cadence: string;
-  checks: string[];
-};
 
 type GeneratedContentItem = Pick<
   ContentItem,
@@ -45,7 +36,10 @@ const normalizeTextModes = (value: unknown): TextMode[] => {
     .filter(isTextMode);
 };
 
-const buildPrompt = (answers: Answers, plan: Plan, strategy: string) => ({
+const buildPrompt = (
+  lessonContext: LessonGenerationContext,
+  strategyContext: StrategyContext,
+) => ({
   system: `You are an education content designer creating short, student-facing science materials.
 Return JSON only with key: items (array).
 Return exactly 1 item in the array.
@@ -56,13 +50,15 @@ Each item must include:
 - textModes: an array using only "questions", "phenomenon", and/or "dialogue"
 - visualBrief: one short sentence describing what the illustration should show
 Do not include teacher directions, facilitation notes, or implementation instructions.`,
-  user: `Student profile:
-${JSON.stringify(answers, null, 2)}
+  user: `Lesson:
+- Title: ${lessonContext.lessonTitle}
+- Learning objective: ${lessonContext.learningObjective}
 
-Engagement plan:
-${JSON.stringify(plan, null, 2)}
+Engagement strategy:
+- Name: ${strategyContext.label}
+- Description: ${strategyContext.description}
 
-Create exactly 1 student-facing content item aligned to the strategy: ${strategy}.
+Create exactly 1 student-facing content item aligned to the lesson objective and strategy.
 The text can use one or a combination of:
 (a) questions,
 (b) a short description of a phenomenon, or
@@ -70,6 +66,7 @@ The text can use one or a combination of:
 
 Requirements:
 - This will be shared directly with students, so write to students instead of to teachers.
+- Make the objective visible in the thinking students are asked to do; do not drift into a generic physics scene.
 - Avoid phrases such as "ask students", "have students", "teacher note", or lesson-delivery instructions.
 - Keep it concrete, vivid, and age-appropriate for middle-school physics learners.
 - The image must clearly reflect the scene or interaction described in the text.
@@ -101,22 +98,40 @@ export async function POST(request: Request) {
   try {
     const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
     const {
-      answers = {},
-      plan,
+      lessonNumber,
       selectedStrategies = [],
     } = (await request.json()) as {
-      answers?: Answers;
-      plan: Plan;
+      lessonNumber?: number;
       selectedStrategies?: string[];
     };
+    if (typeof lessonNumber !== "number") {
+      return NextResponse.json(
+        { error: "lessonNumber is required." },
+        { status: 400 },
+      );
+    }
+
+    const lessonContext = getLessonGenerationContext(lessonNumber);
+    if (!lessonContext) {
+      return NextResponse.json(
+        { error: `Lesson ${lessonNumber} not found.` },
+        { status: 400 },
+      );
+    }
+
     const model = process.env.OPENAI_MODEL ?? "gpt-5-nano";
-    const strategies =
-      selectedStrategies.length > 0 ? selectedStrategies : [plan.strategy];
+    const strategies = selectedStrategies.filter(Boolean);
+    if (strategies.length === 0) {
+      return NextResponse.json(
+        { error: "selectedStrategies must contain at least one strategy." },
+        { status: 400 },
+      );
+    }
     const items: GeneratedResponseItem[] = [];
 
     const strategyResults = await Promise.all(
       strategies.map(async (strategy) => {
-        const prompt = buildPrompt(answers, plan, strategy);
+        const prompt = buildPrompt(lessonContext, getStrategyContext(strategy));
         const completion = await client.chat.completions.create({
           model,
           response_format: { type: "json_object" },

--- a/app/api/engagement-image/route.ts
+++ b/app/api/engagement-image/route.ts
@@ -1,48 +1,45 @@
 import OpenAI from "openai";
 import { NextResponse } from "next/server";
+
+import {
+  getLessonGenerationContext,
+  getStrategyContext,
+} from "@/lib/lesson-context";
 import { getMedia, upsertMedia } from "@/lib/nosql";
-
-type Answers = Record<string, string | undefined>;
-
-type Plan = {
-  name: string;
-  summary: string;
-  rationale: string;
-  tactics: string[];
-  cadence: string;
-  checks: string[];
-};
 
 type ContentItem = {
   id?: string;
   type: string;
+  strategy: string;
   title: string;
   body: string;
   textModes?: string[];
   visualBrief?: string;
 };
 
-const buildPrompt = (
-  item: ContentItem,
-  plan: Plan | null,
-  answers: Answers,
-) => {
-  const topic = answers.topic?.trim() || "gravity";
+const buildPrompt = (item: ContentItem, lessonNumber: number) => {
+  const lessonContext = getLessonGenerationContext(lessonNumber);
+  if (!lessonContext) {
+    throw new Error(`Lesson ${lessonNumber} not found.`);
+  }
+
+  const strategyContext = getStrategyContext(item.strategy);
   const gradeLevel = "8th grade";
-  const planName = plan?.name ?? "Engagement plan";
   const textModes = item.textModes?.length ? item.textModes.join(", ") : item.type;
   const visualBrief = item.visualBrief?.trim();
 
   return `Create a simple, student-friendly illustration for an ${gradeLevel} physics lesson.
 This image will be shown directly to students next to the material below.
-Topic: ${topic}
-Strategy inspiration: ${planName}
+Lesson: ${lessonContext.lessonTitle}
+Learning objective: ${lessonContext.learningObjective}
+Strategy: ${strategyContext.label} - ${strategyContext.description}
 Text style: ${textModes}
 Title: ${item.title}
 Student-facing text:
 ${item.body}
 ${visualBrief ? `Visual brief: ${visualBrief}` : "Visual brief: Show the main scene, phenomenon, or conversation implied by the text."}
 
+Ensure the image supports the lesson objective through the scene students will analyze.
 If the material includes dialogue, clearly show the speakers and what they are reacting to.
 If the material includes questions, show the scene students should reason about.
 If the material describes a phenomenon, make that phenomenon visually central.
@@ -65,22 +62,27 @@ export async function POST(request: Request) {
     const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
     const {
       item,
-      plan,
-      answers = {},
+      lessonNumber,
       classId,
       assignmentId,
       studentId,
     } = (await request.json()) as {
       item: ContentItem;
-      plan: Plan | null;
-      answers?: Answers;
+      lessonNumber?: number;
       classId?: string;
       assignmentId?: string;
       studentId?: string;
     };
 
+    if (typeof lessonNumber !== "number") {
+      return NextResponse.json(
+        { error: "lessonNumber is required." },
+        { status: 400 },
+      );
+    }
+
     const model = process.env.OPENAI_IMAGE_MODEL ?? "gpt-image-1";
-    const prompt = buildPrompt(item, plan, answers);
+    const prompt = buildPrompt(item, lessonNumber);
 
     // webp + low quality = fast generation + small payload (avoids Amplify 30s timeout)
     const result = await client.images.generate({

--- a/app/api/engagement-plan/route.ts
+++ b/app/api/engagement-plan/route.ts
@@ -2,6 +2,10 @@ import OpenAI from "openai";
 import { NextResponse } from "next/server";
 
 import { getCachedPlanJson, upsertCachedPlanJson } from "@/lib/nosql";
+import {
+  deserializeCachedPlan,
+  serializeCachedPlan,
+} from "@/lib/strategy-plan-cache";
 
 type Answers = Record<string, string | undefined>;
 
@@ -144,10 +148,12 @@ export async function POST(request: Request) {
         console.info(
           `engagement-plan cache HIT for ${classKey}/${assignmentKey}/${studentKey}`,
         );
-        const cachedPlan = JSON.parse(cachedPlanJson) as Plan;
-        cachedPlan.strategy = normalizeStrategy(cachedPlan.strategy);
-        const plan = ensurePlanFields(cachedPlan);
-        return NextResponse.json({ plan, cached: true });
+        const cachedPlan = deserializeCachedPlan<Plan>(cachedPlanJson);
+        if (cachedPlan) {
+          cachedPlan.strategy = normalizeStrategy(cachedPlan.strategy);
+          const plan = ensurePlanFields(cachedPlan);
+          return NextResponse.json({ plan, cached: true });
+        }
       }
     }
 
@@ -180,7 +186,7 @@ export async function POST(request: Request) {
         classKey,
         assignmentKey,
         studentKey,
-        JSON.stringify(plan),
+        serializeCachedPlan(plan),
       );
       console.info(
         `engagement-plan cached for ${classKey}/${assignmentKey}/${studentKey}`,

--- a/app/api/strategy-batch/route.ts
+++ b/app/api/strategy-batch/route.ts
@@ -1,7 +1,17 @@
 import OpenAI, { APIConnectionTimeoutError } from "openai";
 import { NextResponse } from "next/server";
 
+import {
+  getLessonGenerationContext,
+  resolveQuizEvidence,
+  type LessonGenerationContext,
+  type ResolvedQuizEvidence,
+} from "@/lib/lesson-context";
 import { getCachedPlanJson, upsertCachedPlanJson } from "@/lib/nosql";
+import {
+  deserializeCachedPlan,
+  serializeCachedPlan,
+} from "@/lib/strategy-plan-cache";
 
 type Answers = Record<string, string | undefined>;
 
@@ -44,26 +54,31 @@ export const maxDuration = 60;
 const STRATEGY_REQUEST_TIMEOUT_MS = 45_000;
 const STRATEGY_BATCH_CONCURRENCY = 4;
 
-const buildPrompt = (student: Student) => ({
+const buildPrompt = (
+  student: Student,
+  lessonContext: LessonGenerationContext | null,
+  quizEvidence: ResolvedQuizEvidence[],
+) => ({
   system: `You are an education engagement planner.
 Return JSON only with keys: name, strategy, relevance, overallRecommendation, recommendationReason, summary, tldr, rationale, tactics, cadence, checks.
 The strategy must be exactly one of: cognitive conflict, analogy, experience bridging, engaged critiquing.
 The relevance field is an object with those four strategies as keys and integer scores from 0-100.
-Use the student's two-question quiz (concept understanding and past experience) to justify the recommendation.
+Base the recommendation primarily on the student's quiz evidence: question text, selected response, confidence, correctness, and any linked misconception.
+Use the lesson learning objective as supplemental context, not as a substitute for the student's quiz evidence.
 Make the recommendationReason reference the student by name and the assignment/topic.
-For recommendationReason and rationale, cite 2+ concrete details from the student's answers and connect them directly to the chosen strategy.`,
+For recommendationReason and rationale, cite 2+ concrete details from the student's quiz evidence and connect them directly to the chosen strategy.`,
   user: `Student name: ${student.name}
-Assignment: ${student.assignment ?? "Not provided"}
+Assignment: ${lessonContext?.lessonTitle ?? student.assignment ?? "Not provided"}
 
-Questionnaire answers:
-${JSON.stringify(student.answers, null, 2)}
+${lessonContext ? `Lesson objective:\n${lessonContext.learningObjective}\n\n` : ""}Structured quiz evidence:
+${quizEvidence.length > 0 ? JSON.stringify(quizEvidence, null, 2) : JSON.stringify(student.answers, null, 2)}
 
 Return a plan:
 - name: short label
 - strategy: one of [cognitive conflict, analogy, experience bridging, engaged critiquing]
 - relevance: scores 0-100 for each strategy
 - overallRecommendation: 1-2 sentences, teacher-facing
-- recommendationReason: 2-3 sentences explaining why this strategy fits ${student.name}; reference the assignment/topic and cite 2+ specific answer details
+- recommendationReason: 2-3 sentences explaining why this strategy fits ${student.name}; reference the assignment/topic and cite 2+ specific quiz-evidence details
 - summary: 1 sentence
 - tldr: 8-14 words, teacher-facing
 - rationale: 3-5 sentences; reference the assignment/topic and include at least one concrete in-class example of how the teacher would use the strategy with ${student.name}
@@ -144,12 +159,16 @@ const generatePlanForStudent = async ({
   classKey,
   assignmentKey,
   student,
+  lessonContext,
+  quizEvidence,
 }: {
   client: OpenAI;
   model: string;
   classKey: string;
   assignmentKey: string;
   student: Student;
+  lessonContext: LessonGenerationContext | null;
+  quizEvidence: ResolvedQuizEvidence[];
 }): Promise<StudentStrategyResult> => {
   const cachedPlanJson = await getCachedPlanJson(
     classKey,
@@ -157,13 +176,18 @@ const generatePlanForStudent = async ({
     student.id,
   );
   if (cachedPlanJson) {
-    const cachedPlan = JSON.parse(cachedPlanJson) as Plan;
-    cachedPlan.strategy = normalizeStrategy(cachedPlan.strategy);
-    const plan = ensurePlanFields(cachedPlan);
-    return { id: student.id, name: student.name, plan };
+    const cachedPlan = deserializeCachedPlan<Plan>(cachedPlanJson, {
+      lessonNumber: lessonContext?.lessonNumber,
+      requireVersionMatch: lessonContext !== null,
+    });
+    if (cachedPlan) {
+      cachedPlan.strategy = normalizeStrategy(cachedPlan.strategy);
+      const plan = ensurePlanFields(cachedPlan);
+      return { id: student.id, name: student.name, plan };
+    }
   }
 
-  const prompt = buildPrompt(student);
+  const prompt = buildPrompt(student, lessonContext, quizEvidence);
   const completion = await client.chat.completions.create({
     model,
     response_format: { type: "json_object" },
@@ -181,7 +205,7 @@ const generatePlanForStudent = async ({
     classKey,
     assignmentKey,
     student.id,
-    JSON.stringify(plan),
+    serializeCachedPlan(plan, lessonContext?.lessonNumber),
   );
 
   return { id: student.id, name: student.name, plan };
@@ -206,16 +230,29 @@ export async function POST(request: Request) {
       students = [],
       classId,
       assignmentId,
+      lessonNumber,
     } = (await request.json()) as {
       students?: Student[];
       classId?: string;
       assignmentId?: string;
+      lessonNumber?: number;
     };
     const classKey = classId?.trim();
     const assignmentKey = assignmentId?.trim();
     if (!classKey || !assignmentKey) {
       return NextResponse.json(
         { error: "classId and assignmentId are required." },
+        { status: 400 },
+      );
+    }
+
+    const lessonContext =
+      typeof lessonNumber === "number"
+        ? getLessonGenerationContext(lessonNumber)
+        : null;
+    if (typeof lessonNumber === "number" && !lessonContext) {
+      return NextResponse.json(
+        { error: `Lesson ${lessonNumber} not found.` },
         { status: 400 },
       );
     }
@@ -234,6 +271,11 @@ export async function POST(request: Request) {
             classKey,
             assignmentKey,
             student,
+            lessonContext,
+            quizEvidence:
+              typeof lessonNumber === "number"
+                ? resolveQuizEvidence(lessonNumber, student.answers)
+                : [],
           }),
         ),
       );

--- a/app/api/strategy-cache/route.ts
+++ b/app/api/strategy-cache/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { listCachedPlans } from "@/lib/nosql";
+import { deserializeCachedPlan } from "@/lib/strategy-plan-cache";
 
 export const runtime = "nodejs";
 
@@ -19,10 +20,25 @@ export async function GET(request: NextRequest) {
   const classId = searchParams.get("classId")?.trim();
   const assignmentId = searchParams.get("assignmentId")?.trim();
   const studentId = searchParams.get("studentId")?.trim() || undefined;
+  const lessonNumberParam = searchParams.get("lessonNumber");
 
   if (!classId || !assignmentId) {
     return NextResponse.json(
       { error: "classId and assignmentId are required query parameters." },
+      { status: 400 },
+    );
+  }
+
+  const lessonNumber =
+    lessonNumberParam === null
+      ? undefined
+      : Number.parseInt(lessonNumberParam, 10);
+  if (
+    lessonNumberParam !== null &&
+    (Number.isNaN(lessonNumber) || (lessonNumber ?? 0) < 1)
+  ) {
+    return NextResponse.json(
+      { error: "lessonNumber must be a positive integer when provided." },
       { status: 400 },
     );
   }
@@ -33,19 +49,33 @@ export async function GET(request: NextRequest) {
       `strategy-cache: classId=${classId} assignmentId=${assignmentId} → ${records.length} cached plan(s)`,
     );
 
-    const results = records.map((record) => {
-      let plan: unknown = null;
-      try {
-        plan = JSON.parse(record.plan_json);
-      } catch {
-        plan = record.plan_json;
-      }
-      return {
-        studentId: record.student_id,
-        plan,
-        updatedAt: record.updated_at,
-      };
-    });
+    const results = records
+      .map((record) => {
+        try {
+          const plan = deserializeCachedPlan(record.plan_json, {
+            lessonNumber,
+            requireVersionMatch: lessonNumber !== undefined,
+          });
+          if (!plan) {
+            return null;
+          }
+          return {
+            studentId: record.student_id,
+            plan,
+            updatedAt: record.updated_at,
+          };
+        } catch {
+          if (lessonNumber !== undefined) {
+            return null;
+          }
+          return {
+            studentId: record.student_id,
+            plan: record.plan_json,
+            updatedAt: record.updated_at,
+          };
+        }
+      })
+      .filter((result): result is NonNullable<typeof result> => Boolean(result));
 
     return NextResponse.json({ results, count: results.length });
   } catch (error) {

--- a/app/api/strategy-single/route.ts
+++ b/app/api/strategy-single/route.ts
@@ -1,7 +1,17 @@
 import OpenAI from "openai";
 import { NextResponse } from "next/server";
 
+import {
+  getLessonGenerationContext,
+  resolveQuizEvidence,
+  type LessonGenerationContext,
+  type ResolvedQuizEvidence,
+} from "@/lib/lesson-context";
 import { getCachedPlanJson, upsertCachedPlanJson } from "@/lib/nosql";
+import {
+  deserializeCachedPlan,
+  serializeCachedPlan,
+} from "@/lib/strategy-plan-cache";
 
 type Answers = Record<string, string | undefined>;
 
@@ -31,26 +41,31 @@ export const maxDuration = 60;
 
 const STRATEGY_REQUEST_TIMEOUT_MS = 45_000;
 
-const buildPrompt = (student: Student) => ({
+const buildPrompt = (
+  student: Student,
+  lessonContext: LessonGenerationContext | null,
+  quizEvidence: ResolvedQuizEvidence[],
+) => ({
   system: `You are an education engagement planner.
 Return JSON only with keys: name, strategy, relevance, overallRecommendation, recommendationReason, summary, tldr, rationale, tactics, cadence, checks.
 The strategy must be exactly one of: cognitive conflict, analogy, experience bridging, engaged critiquing.
 The relevance field is an object with those four strategies as keys and integer scores from 0-100.
-Use the student's two-question quiz (concept understanding and past experience) to justify the recommendation.
+Base the recommendation primarily on the student's quiz evidence: question text, selected response, confidence, correctness, and any linked misconception.
+Use the lesson learning objective as supplemental context, not as a substitute for the student's quiz evidence.
 Make the recommendationReason reference the student by name and the assignment/topic.
-For recommendationReason and rationale, cite 2+ concrete details from the student's answers and connect them directly to the chosen strategy.`,
+For recommendationReason and rationale, cite 2+ concrete details from the student's quiz evidence and connect them directly to the chosen strategy.`,
   user: `Student name: ${student.name}
-Assignment: ${student.assignment ?? "Not provided"}
+Assignment: ${lessonContext?.lessonTitle ?? student.assignment ?? "Not provided"}
 
-Questionnaire answers:
-${JSON.stringify(student.answers, null, 2)}
+${lessonContext ? `Lesson objective:\n${lessonContext.learningObjective}\n\n` : ""}Structured quiz evidence:
+${quizEvidence.length > 0 ? JSON.stringify(quizEvidence, null, 2) : JSON.stringify(student.answers, null, 2)}
 
 Return a plan:
 - name: short label
 - strategy: one of [cognitive conflict, analogy, experience bridging, engaged critiquing]
 - relevance: scores 0-100 for each strategy
 - overallRecommendation: 1-2 sentences, teacher-facing
-- recommendationReason: 2-3 sentences explaining why this strategy fits ${student.name}; reference the assignment/topic and cite 2+ specific answer details
+- recommendationReason: 2-3 sentences explaining why this strategy fits ${student.name}; reference the assignment/topic and cite 2+ specific quiz-evidence details
 - summary: 1 sentence
 - tldr: 8-14 words, teacher-facing
 - rationale: 3-5 sentences; reference the assignment/topic and include at least one concrete in-class example of how the teacher would use the strategy with ${student.name}
@@ -110,10 +125,11 @@ export async function POST(request: Request) {
       timeout: STRATEGY_REQUEST_TIMEOUT_MS,
       maxRetries: 0,
     });
-    const { student, classId, assignmentId } = (await request.json()) as {
+    const { student, classId, assignmentId, lessonNumber } = (await request.json()) as {
       student: Student;
       classId?: string;
       assignmentId?: string;
+      lessonNumber?: number;
     };
     const classKey = classId?.trim();
     const assignmentKey = assignmentId?.trim();
@@ -130,20 +146,42 @@ export async function POST(request: Request) {
       );
     }
 
+    const lessonContext =
+      typeof lessonNumber === "number"
+        ? getLessonGenerationContext(lessonNumber)
+        : null;
+    if (typeof lessonNumber === "number" && !lessonContext) {
+      return NextResponse.json(
+        { error: `Lesson ${lessonNumber} not found.` },
+        { status: 400 },
+      );
+    }
+
     const cachedPlanJson = await getCachedPlanJson(
       classKey,
       assignmentKey,
       student.id,
     );
     if (cachedPlanJson) {
-      const cachedPlan = JSON.parse(cachedPlanJson) as Plan;
-      cachedPlan.strategy = normalizeStrategy(cachedPlan.strategy);
-      const plan = ensurePlanFields(cachedPlan);
-      return NextResponse.json({ plan });
+      const cachedPlan = deserializeCachedPlan<Plan>(cachedPlanJson, {
+        lessonNumber: lessonContext?.lessonNumber,
+        requireVersionMatch: lessonContext !== null,
+      });
+      if (cachedPlan) {
+        cachedPlan.strategy = normalizeStrategy(cachedPlan.strategy);
+        const plan = ensurePlanFields(cachedPlan);
+        return NextResponse.json({ plan });
+      }
     }
 
     const model = process.env.OPENAI_MODEL ?? "gpt-5-nano";
-    const prompt = buildPrompt(student);
+    const prompt = buildPrompt(
+      student,
+      lessonContext,
+      typeof lessonNumber === "number"
+        ? resolveQuizEvidence(lessonNumber, student.answers)
+        : [],
+    );
     const completion = await client.chat.completions.create({
       model,
       response_format: { type: "json_object" },
@@ -161,7 +199,7 @@ export async function POST(request: Request) {
       classKey,
       assignmentKey,
       student.id,
-      JSON.stringify(plan),
+      serializeCachedPlan(plan, lessonContext?.lessonNumber),
     );
 
     return NextResponse.json({ plan });

--- a/app/api/student-answers/route.ts
+++ b/app/api/student-answers/route.ts
@@ -6,6 +6,7 @@ export async function GET(request: Request) {
   const classId = searchParams.get("classId");
   const assignmentId = searchParams.get("assignmentId");
   const studentId = searchParams.get("studentId");
+  const lessonNumberParam = searchParams.get("lessonNumber");
 
   if (!classId || !assignmentId) {
     return NextResponse.json(
@@ -14,13 +15,32 @@ export async function GET(request: Request) {
     );
   }
 
+  const lessonNumber =
+    lessonNumberParam === null ? undefined : Number.parseInt(lessonNumberParam, 10);
+  if (
+    lessonNumberParam !== null &&
+    (Number.isNaN(lessonNumber) || (lessonNumber ?? 0) < 1)
+  ) {
+    return NextResponse.json(
+      { error: "lessonNumber must be a positive integer when provided." },
+      { status: 400 },
+    );
+  }
+
   if (studentId) {
     const answer = await getStudentAnswer(classId, assignmentId, studentId);
+    if (lessonNumber !== undefined && answer?.lesson_number !== lessonNumber) {
+      return NextResponse.json({ answer: null });
+    }
     return NextResponse.json({ answer });
   }
 
   const answers = await listStudentAnswers(classId, assignmentId);
-  return NextResponse.json({ answers });
+  const filteredAnswers =
+    lessonNumber === undefined
+      ? answers
+      : answers.filter((answer) => answer.lesson_number === lessonNumber);
+  return NextResponse.json({ answers: filteredAnswers });
 }
 
 export async function POST(request: Request) {

--- a/app/components/StudentQuizView.tsx
+++ b/app/components/StudentQuizView.tsx
@@ -77,7 +77,7 @@ export default function StudentQuizView({ user }: Props) {
 
       // Check for existing answers
       const answerRes = await fetch(
-        `/api/student-answers?classId=${encodeURIComponent(classId)}&assignmentId=${encodeURIComponent(assignmentId)}&studentId=${encodeURIComponent(user.userId)}`,
+        `/api/student-answers?classId=${encodeURIComponent(classId)}&assignmentId=${encodeURIComponent(assignmentId)}&studentId=${encodeURIComponent(user.userId)}&lessonNumber=${encodeURIComponent(qs.lesson_number)}`,
       );
       const answerData = await answerRes.json();
       if (answerData.answer) {

--- a/app/components/TeacherView.tsx
+++ b/app/components/TeacherView.tsx
@@ -937,6 +937,18 @@ export default function TeacherView({ user }: Props) {
 
   const selectLesson = async (lessonNumber: number) => {
     setSelectedLesson(lessonNumber);
+    setPlan(null);
+    setSelectedStrategies([]);
+    setAnnotationDecision(null);
+    setAnnotationReason("");
+    setAnnotationStatus("idle");
+    setContent([]);
+    setImages({});
+    setVideos({});
+    setSelectedForPublish(new Set());
+    setPublishedContentIds(new Set());
+    setCohortResults([]);
+    setCohortDistribution({});
     const res = await fetch(`/api/lessons/${lessonNumber}`);
     const data = await res.json();
     setQuizItems(data.quiz_items ?? []);
@@ -993,13 +1005,13 @@ export default function TeacherView({ user }: Props) {
   };
 
   const loadStudentAnswers = async (options?: { silent?: boolean }) => {
-    if (!classId || !assignmentId) return;
+    if (!classId || !assignmentId || !selectedLesson) return;
     const silent = options?.silent ?? false;
     if (!silent) {
       setLoadingAnswers(true);
     }
     try {
-      const res = await fetch(`/api/student-answers?classId=${encodeURIComponent(classId)}&assignmentId=${encodeURIComponent(assignmentId)}`);
+      const res = await fetch(`/api/student-answers?classId=${encodeURIComponent(classId)}&assignmentId=${encodeURIComponent(assignmentId)}&lessonNumber=${encodeURIComponent(selectedLesson)}`);
       const data = await res.json();
       setStudentAnswers(data.answers ?? []);
     } catch {
@@ -1025,7 +1037,7 @@ export default function TeacherView({ user }: Props) {
 
     return () => window.clearInterval(intervalId);
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentStep, quizStatus, classId, assignmentId]);
+  }, [currentStep, quizStatus, classId, assignmentId, selectedLesson]);
 
   useEffect(() => {
     if (!loadingCohort) {
@@ -1043,6 +1055,10 @@ export default function TeacherView({ user }: Props) {
 
   const requestCohortAnalysis = async () => {
     if (!classId || !assignmentId) return;
+    if (!selectedLesson) {
+      setError("Select a lesson before generating strategies.");
+      return;
+    }
     if (studentAnswers.length === 0) {
       setError("No student answers available. Wait for students to submit.");
       return;
@@ -1068,7 +1084,7 @@ export default function TeacherView({ user }: Props) {
         answers: sa.answers,
       }));
 
-      const cacheUrl = `/api/strategy-cache?classId=${encodeURIComponent(classId)}&assignmentId=${encodeURIComponent(assignmentId)}`;
+      const cacheUrl = `/api/strategy-cache?classId=${encodeURIComponent(classId)}&assignmentId=${encodeURIComponent(assignmentId)}&lessonNumber=${encodeURIComponent(selectedLesson)}`;
       const cacheRes = await fetch(cacheUrl);
       let cacheData: { results?: Array<{ studentId?: string; plan?: unknown }> } = { results: [] };
       if (cacheRes.ok) {
@@ -1135,6 +1151,7 @@ export default function TeacherView({ user }: Props) {
               students: pendingStudents,
               classId,
               assignmentId,
+              lessonNumber: selectedLesson,
             }),
           });
           const data = await parseJsonResponse<StrategyBatchResponse>(res);
@@ -1217,6 +1234,10 @@ export default function TeacherView({ user }: Props) {
 
   const requestContent = async () => {
     if (!plan || selectedStrategies.length === 0) return;
+    if (!selectedLesson) {
+      setError("Select a lesson before generating content.");
+      return;
+    }
     setLoadingContent(true);
     setError(null);
     setContent([]);
@@ -1225,8 +1246,7 @@ export default function TeacherView({ user }: Props) {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          answers: {},
-          plan,
+          lessonNumber: selectedLesson,
           selectedStrategies,
         }),
       });
@@ -1356,7 +1376,7 @@ export default function TeacherView({ user }: Props) {
 
   // Image generation effect
   useEffect(() => {
-    if (isRestoringStep3State || !content.length) return;
+    if (isRestoringStep3State || !content.length || !selectedLesson) return;
     const pending = content.filter((item) => !images[item.id]?.status);
     if (pending.length === 0) return;
 
@@ -1374,7 +1394,13 @@ export default function TeacherView({ user }: Props) {
           const res = await fetch("/api/engagement-image", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ item, plan, answers: {}, classId, assignmentId, studentId: "cohort" }),
+            body: JSON.stringify({
+              item,
+              lessonNumber: selectedLesson,
+              classId,
+              assignmentId,
+              studentId: "cohort",
+            }),
           });
           const text = await res.text();
           let data: Record<string, unknown>;
@@ -1389,7 +1415,7 @@ export default function TeacherView({ user }: Props) {
 
     return () => { cancelled = true; };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [content, isRestoringStep3State]);
+  }, [content, isRestoringStep3State, selectedLesson]);
 
   const requestVideo = async (item: ContentItem) => {
     const imageUrl = images[item.id]?.url;
@@ -1438,6 +1464,9 @@ export default function TeacherView({ user }: Props) {
     }
   };
 
+
+  const selectedLessonData =
+    lessons.find((lesson) => lesson.lesson_number === selectedLesson) ?? null;
 
   return (
     <div className="min-h-screen bg-slate-50 text-slate-900">
@@ -1509,6 +1538,15 @@ export default function TeacherView({ user }: Props) {
                 <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">Step 1</p>
                 <h2 className="text-2xl font-semibold text-slate-900">Select lesson & publish quiz</h2>
               </div>
+
+              {selectedLessonData && (
+                <div className="rounded-2xl border border-[#BA0C2F]/15 bg-[#BA0C2F]/5 p-5">
+                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[#BA0C2F]">Learning objective</p>
+                  <p className="mt-2 text-sm leading-6 text-slate-700">
+                    {selectedLessonData.learning_objective}
+                  </p>
+                </div>
+              )}
 
               {/* Lesson picker */}
               <div className="grid gap-3">

--- a/data/lesson1.json
+++ b/data/lesson1.json
@@ -1,6 +1,7 @@
 {
   "lesson_number": 1,
   "lesson_title": "Lesson 1",
+  "learning_objective": "Students will construct temporal visual models and causal explanations to link unobservable energy transfer and interaction forces to the observable macroscopic changes in an object's shape and motion before and after an impact.",
   "core_ideas": [
     "In a collision between two objects, the objects have to come into contact; sometimes something is damaged, but not always.",
     "Different factors and variables may cause objects to be damaged or not damaged in a collision."

--- a/data/lesson2.json
+++ b/data/lesson2.json
@@ -1,6 +1,7 @@
 {
   "lesson_number": 2,
   "lesson_title": "Lesson 2",
+  "learning_objective": "Students will systematically analyze simulated collision data to link kinetic energy to physical changes, evaluating through peer argumentation whether energy transfer or force is the primary mechanism driving these alterations.",
   "core_ideas": [
     "The motion of an object is determined by the sum of the forces acting on it; if the total force on the object is not zero, its motion will change.",
     "A collision can cause the objects involved to change motion and/or change shape.",

--- a/data/lesson3.json
+++ b/data/lesson3.json
@@ -1,6 +1,7 @@
 {
   "lesson_number": 3,
   "lesson_title": "Lesson 3",
+  "learning_objective": "Students will reconcile macroscopic observations with microscopic evidence to conclude that all materials deform during collisions, applying this empirical evidence to critique opposing claims during peer argumentation.",
   "core_ideas": [
     "All solid objects bend or change shape in a collision and when other contact forces are applied to them."
   ],

--- a/data/lesson4.json
+++ b/data/lesson4.json
@@ -1,6 +1,7 @@
 {
   "lesson_number": 4,
   "lesson_title": "Lesson 4",
+  "learning_objective": "Students will design multivariable virtual experiments and analyze force-deformation graphs to isolate how applied force, material type, and thickness dictate an object's elastic limit and fracture point.",
   "core_ideas": [
     "All solid objects deform elastically when force is applied to them, up to a point.",
     "Different objects have a different elastic limit, which is the maximum amount of deformation they can withstand, beyond which they will deform permanently.",

--- a/data/lesson5.json
+++ b/data/lesson5.json
@@ -1,6 +1,7 @@
 {
   "lesson_number": 5,
   "lesson_title": "Lesson 5",
+  "learning_objective": "Students will execute controlled experiments and develop free-body diagrams to demonstrate how independent variations in an object's initial mass or speed alter equal-and-opposite peak contact forces and subsequent energy transfer.",
   "core_ideas": [
     "Objects that make contact with each other apply equally strong forces on each other in opposite directions.",
     "Objects that collide apply an equally strong peak force (maximum force) on each other during the collision.",

--- a/data/lesson6.json
+++ b/data/lesson6.json
@@ -1,6 +1,7 @@
 {
   "lesson_number": 6,
   "lesson_title": "Lesson 6",
+  "learning_objective": "Students will model real-world collisions to demonstrate Newton's Third Law, synthesizing kinematic data to argue which specific scenarios generate peak forces that exceed the elastic limits of biological tissues.",
   "core_ideas": [
     "Application of concepts from Lessons 1-5."
   ],

--- a/data/lesson7.json
+++ b/data/lesson7.json
@@ -1,6 +1,7 @@
 {
   "lesson_number": 7,
   "lesson_title": "Lesson 7",
+  "learning_objective": "Students will analyze graphical data to differentiate the linear effect of mass from the nonlinear effect of speed on kinetic energy, arguing quantitatively that doubling velocity produces a disproportionately larger increase in collision damage.",
   "core_ideas": [
     "The more kinetic energy an object has the more damage it can do in a collision.",
     "The more kinetic energy an object has the more you have to push against the direction of its motion to get it to stop.",

--- a/data/lesson8.json
+++ b/data/lesson8.json
@@ -1,6 +1,7 @@
 {
   "lesson_number": 8,
   "lesson_title": "Lesson 8",
+  "learning_objective": "Students will construct comprehensive system models and annotate free-body diagrams to map the continuous transformation of energy and account for macroscopic energy dissipation via secondary contact forces.",
   "core_ideas": [
     "The more force you apply to an object the more that object speeds up.",
     "It takes more force to speed up a more massive object the same amount as a lower mass object.",

--- a/lib/lesson-context.ts
+++ b/lib/lesson-context.ts
@@ -1,0 +1,143 @@
+import {
+  getEngagementStrategyDescription,
+  getEngagementStrategyLabel,
+} from "./engagement-strategies";
+import { getLesson } from "./quiz-data";
+import type { Lesson } from "./types";
+
+type StudentAnswers = Record<string, string | undefined>;
+
+export type LessonGenerationContext = {
+  lessonNumber: number;
+  lessonTitle: string;
+  learningObjective: string;
+};
+
+export type StrategyContext = {
+  id: string;
+  label: string;
+  description: string;
+};
+
+export type ResolvedQuizEvidence = {
+  itemId: string;
+  questionNumber?: number;
+  stem: string;
+  selectedOption: string | null;
+  selectedText: string | null;
+  correctOption: string | null;
+  correctText: string | null;
+  isCorrect: boolean | null;
+  confidenceOption: string | null;
+  confidenceText: string | null;
+  misconceptionCode: string | null;
+  misconceptionText: string | null;
+};
+
+const splitMisconceptionCodes = (value: string | null | undefined) =>
+  value
+    ?.split(",")
+    .map((part) => part.trim())
+    .filter(Boolean) ?? [];
+
+const resolveMisconceptionText = (
+  lesson: Lesson,
+  misconceptionCode: string | null,
+) => {
+  const codes = splitMisconceptionCodes(misconceptionCode);
+  if (codes.length === 0) {
+    return null;
+  }
+
+  return codes
+    .map((code) => lesson.misconceptions[code] ?? code)
+    .join("; ");
+};
+
+const getConfidenceText = (
+  lesson: Lesson,
+  itemId: string,
+  selectedOption: string | null,
+) => {
+  if (!selectedOption) {
+    return null;
+  }
+
+  const confidenceItem = lesson.quiz_items.find(
+    (item) => item.item_id === `${itemId}_confidence`,
+  );
+  if (!confidenceItem) {
+    return null;
+  }
+
+  return confidenceItem.options[selectedOption] ?? null;
+};
+
+export const getLessonGenerationContext = (
+  lessonNumber: number,
+): LessonGenerationContext | null => {
+  const lesson = getLesson(lessonNumber);
+  if (!lesson) {
+    return null;
+  }
+
+  return {
+    lessonNumber: lesson.lesson_number,
+    lessonTitle: lesson.lesson_title,
+    learningObjective: lesson.learning_objective,
+  };
+};
+
+export const getStrategyContext = (strategyId: string): StrategyContext => ({
+  id: strategyId,
+  label: getEngagementStrategyLabel(strategyId),
+  description: getEngagementStrategyDescription(strategyId),
+});
+
+export const resolveQuizEvidence = (
+  lessonNumber: number,
+  answers: StudentAnswers,
+): ResolvedQuizEvidence[] => {
+  const lesson = getLesson(lessonNumber);
+  if (!lesson) {
+    return [];
+  }
+
+  return lesson.quiz_items
+    .filter((item) => item.type === "multiple_choice")
+    .map((item) => {
+      const selectedOption = answers[item.item_id]?.trim().toUpperCase() ?? null;
+      const correctOption = item.correct_answer?.trim().toUpperCase() ?? null;
+      const confidenceOption =
+        answers[`${item.item_id}_confidence`]?.trim().toUpperCase() ?? null;
+      const isCorrect =
+        selectedOption && correctOption
+          ? selectedOption === correctOption
+          : null;
+      const misconceptionCode =
+        selectedOption && correctOption && selectedOption !== correctOption
+          ? item.distractor_misconception_map?.[selectedOption] ??
+            item.matched_misconception ??
+            null
+          : null;
+
+      return {
+        itemId: item.item_id,
+        questionNumber: item.question_number,
+        stem: item.stem,
+        selectedOption,
+        selectedText: selectedOption ? item.options[selectedOption] ?? null : null,
+        correctOption,
+        correctText: correctOption ? item.options[correctOption] ?? null : null,
+        isCorrect,
+        confidenceOption,
+        confidenceText: getConfidenceText(
+          lesson,
+          item.item_id,
+          confidenceOption,
+        ),
+        misconceptionCode,
+        misconceptionText: resolveMisconceptionText(lesson, misconceptionCode),
+      };
+    });
+};

--- a/lib/quiz-data.ts
+++ b/lib/quiz-data.ts
@@ -14,7 +14,7 @@ type RawQuizItem = Omit<QuizItem, "type"> & {
 };
 
 type RawLesson = Omit<Lesson, "misconceptions" | "quiz_items"> & {
-  misconceptions: Lesson["misconceptions"] | Record<string, string>;
+  misconceptions: Lesson["misconceptions"];
   quiz_items: RawQuizItem[];
 };
 
@@ -36,9 +36,6 @@ function normalizeQuizItem(rawItem: RawQuizItem): QuizItem {
 function normalizeLesson(rawLesson: RawLesson): Lesson {
   return {
     ...rawLesson,
-    misconceptions: Array.isArray(rawLesson.misconceptions)
-      ? rawLesson.misconceptions
-      : Object.values(rawLesson.misconceptions),
     quiz_items: rawLesson.quiz_items.map(normalizeQuizItem),
   };
 }

--- a/lib/strategy-plan-cache.ts
+++ b/lib/strategy-plan-cache.ts
@@ -1,0 +1,57 @@
+const STRATEGY_PLAN_CACHE_VERSION = 2;
+
+type CachedPlanEnvelope<TPlan> = {
+  promptVersion: number;
+  lessonNumber: number | null;
+  plan: TPlan;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+export const serializeCachedPlan = <TPlan>(
+  plan: TPlan,
+  lessonNumber?: number,
+) =>
+  JSON.stringify({
+    promptVersion: STRATEGY_PLAN_CACHE_VERSION,
+    lessonNumber: typeof lessonNumber === "number" ? lessonNumber : null,
+    plan,
+  } satisfies CachedPlanEnvelope<TPlan>);
+
+export const deserializeCachedPlan = <TPlan>(
+  planJson: string,
+  options?: {
+    lessonNumber?: number;
+    requireVersionMatch?: boolean;
+  },
+): TPlan | null => {
+  const parsed = JSON.parse(planJson) as unknown;
+
+  if (
+    isRecord(parsed) &&
+    "promptVersion" in parsed &&
+    "plan" in parsed
+  ) {
+    const promptVersion =
+      typeof parsed.promptVersion === "number" ? parsed.promptVersion : null;
+    if (promptVersion !== STRATEGY_PLAN_CACHE_VERSION) {
+      return null;
+    }
+
+    if (
+      typeof options?.lessonNumber === "number" &&
+      parsed.lessonNumber !== options.lessonNumber
+    ) {
+      return null;
+    }
+
+    return parsed.plan as TPlan;
+  }
+
+  if (options?.requireVersionMatch) {
+    return null;
+  }
+
+  return parsed as TPlan;
+};

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -59,8 +59,9 @@ export type QuizItem = {
 export type Lesson = {
   lesson_number: number;
   lesson_title: string;
+  learning_objective: string;
   core_ideas: string[];
-  misconceptions: string[];
+  misconceptions: Record<string, string>;
   quiz_items: QuizItem[];
 };
 


### PR DESCRIPTION
## Summary
- add `learning_objective` to the lesson schema and populate all 8 lesson JSON files
- keep strategy generation quiz-driven, but upgrade it to use resolved quiz semantics plus lesson objective as supplemental context
- drive engagement content and image generation from `lesson objective + selected strategy` instead of the previous generic payloads
- surface the selected lesson objective in Step 1 and scope student answers / cached strategy plans to the active lesson

## What Changed

### Lesson data and typing
- Added `learning_objective: string` to the `Lesson` type.
- Preserved `misconceptions` as keyed records instead of flattening them so quiz analysis can map distractors back to specific misconception text.
- Added the provided learning objective to each lesson file in `data/lesson1.json` through `data/lesson8.json`.

### Shared lesson context helpers
- Added `lib/lesson-context.ts` to centralize:
  - lesson generation context (`lesson number`, `lesson title`, `learning objective`)
  - strategy label/description lookup
  - semantic quiz evidence resolution from raw student answer letters
- Quiz evidence now includes question stem, selected option text, correct option text, correctness, confidence response, and linked misconception text.

### Strategy generation
- Updated `strategy-batch` and `strategy-single` to prompt from structured quiz evidence instead of opaque answer maps.
- Lesson objectives are included as supplemental context, while the recommendation remains grounded in quiz evidence and student responses.
- Added lesson-aware cache envelopes in `lib/strategy-plan-cache.ts` so stale plans are not reused across lesson changes.
- Updated `strategy-cache` reads to filter/deserialize lesson-scoped cached plans.

### Content generation
- Updated `engagement-content` so generated text is based on:
  - selected lesson
  - lesson learning objective
  - selected strategy (label + description)
- Removed the prior dependency on empty placeholder `answers` objects and broad plan blobs for this stage.

### Image generation
- Updated `engagement-image` so image prompts receive the lesson objective and selected strategy context.
- Removed the old generic topic fallback behavior that previously defaulted to `gravity`.

### Teacher / student flow updates
- `TeacherView` now:
  - shows the selected lesson objective in Step 1
  - clears downstream strategy/content state when the lesson changes
  - passes `lessonNumber` into strategy/content/image generation routes
  - requests lesson-scoped cached plans and lesson-scoped student answers
- `StudentQuizView` now requests the student's existing answer record scoped to the current lesson.
- `student-answers` GET supports optional `lessonNumber` filtering to avoid cross-lesson answer leakage inside the same assignment.

## Testing
- Added `__tests__/lib/lesson-context.test.ts` for lesson-objective lookup, strategy metadata lookup, and quiz-evidence resolution.
- Updated lesson data tests to assert `learning_objective` exists and keyed misconceptions still load correctly.
- Updated strategy-batch tests to assert the prompt contains both the lesson objective and resolved quiz evidence.
- Added a student-answer API test to verify lesson-level filtering.

## Validation
- `npm test -- --run`
- `npm run build`

## Lint Status
- `npm run lint -- .` still fails due to a pre-existing unrelated error in `app/components/AuthContext.tsx:180` (`react-hooks/set-state-in-effect`) plus several existing warnings.
- I did not change that file as part of this PR.

## Notes
- The untracked `workers/` directory in the local worktree was left untouched and is not included in this PR.
