### PR TITLE
Fix student media delivery for published content

### DIFF
--- a/__tests__/api/engagement-video-status.test.ts
+++ b/__tests__/api/engagement-video-status.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const { upsertMedia, getMedia } = vi.hoisted(() => ({
+  upsertMedia: vi.fn(),
+  getMedia: vi.fn(),
+}));
+
+vi.mock("@/lib/nosql", () => ({
+  upsertMedia,
+  getMedia,
+}));
+
+import { GET } from "@/app/api/engagement-video/status/route";
+
+describe("GET /api/engagement-video/status", () => {
+  beforeEach(() => {
+    process.env.GROK_API_KEY = "test-grok-key";
+    upsertMedia.mockReset();
+    getMedia.mockReset();
+    vi.unstubAllGlobals();
+  });
+
+  it("should return the persisted video url when media is saved successfully", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            status: "done",
+            video: {
+              url: "https://upstream.example.com/video.mp4",
+            },
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(Buffer.from("video-bytes"), {
+          status: 200,
+          headers: { "Content-Type": "video/mp4" },
+        }),
+      );
+
+    vi.stubGlobal("fetch", fetchMock);
+    getMedia.mockResolvedValue({
+      data_url: "https://cdn.example.com/video.mp4",
+    });
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/engagement-video/status?requestId=req-1&contentItemId=item-1&classId=c1&assignmentId=a1&studentId=cohort",
+    );
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      done: true,
+      url: "https://cdn.example.com/video.mp4",
+      contentItemId: "item-1",
+      savedToDb: true,
+    });
+    expect(upsertMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        classId: "c1",
+        assignmentId: "a1",
+        studentId: "cohort",
+        contentItemId: "item-1",
+        mediaType: "video",
+        mimeType: "video/mp4",
+      }),
+    );
+    expect(getMedia).toHaveBeenCalledWith(
+      "c1",
+      "a1",
+      "cohort",
+      "item-1",
+      "video",
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/__tests__/lib/published-content.test.ts
+++ b/__tests__/lib/published-content.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { buildPublishedContentState } from "@/lib/published-content";
+
+describe("buildPublishedContentState", () => {
+  it("should merge embedded, published, and direct media using the published content id", () => {
+    const state = buildPublishedContentState(
+      [
+        {
+          content_item_id: "item-1",
+          content_json: JSON.stringify({
+            id: "temporary-id",
+            type: "Dialogue",
+            title: "Elastic Limit",
+            body: "Body",
+            strategy: "analogy",
+            textModes: ["dialogue", "invalid"],
+            visualBrief: "A lab scene",
+            media: {
+              image: "https://embedded.example.com/image.webp",
+            },
+          }),
+          media: {
+            video: "https://published.example.com/video.mp4",
+          },
+        },
+      ],
+      [
+        {
+          content_item_id: "item-1",
+          media_type: "image",
+          data_url: "https://media.example.com/image.webp",
+        },
+      ],
+    );
+
+    expect(state.contentItems).toEqual([
+      {
+        id: "item-1",
+        type: "Dialogue",
+        title: "Elastic Limit",
+        body: "Body",
+        strategy: "analogy",
+        textModes: ["dialogue"],
+        visualBrief: "A lab scene",
+      },
+    ]);
+    expect(state.mediaByItemId).toEqual({
+      "item-1": {
+        image: "https://media.example.com/image.webp",
+        video: "https://published.example.com/video.mp4",
+      },
+    });
+  });
+
+  it("should fall back safely when content json is invalid or media is blank", () => {
+    const state = buildPublishedContentState(
+      [
+        {
+          content_item_id: "item-2",
+          content_json: "{not-json}",
+          media: {
+            image: "   ",
+          },
+        },
+      ],
+      [
+        {
+          content_item_id: "item-2",
+          media_type: "video",
+          data_url: "",
+        },
+      ],
+    );
+
+    expect(state.contentItems).toEqual([
+      {
+        id: "item-2",
+        type: "unknown",
+        title: "Content",
+        body: "",
+        strategy: "",
+      },
+    ]);
+    expect(state.mediaByItemId).toEqual({});
+  });
+});

--- a/app/api/engagement-video/status/route.ts
+++ b/app/api/engagement-video/status/route.ts
@@ -90,6 +90,7 @@ export async function GET(request: NextRequest) {
 
     let savedToDb = false;
     let saveError: string | null = null;
+    let responseUrl = videoUrl;
 
     // Persist video to S3/DB before responding — must be awaited because
     // serverless Lambdas freeze after the response is sent.
@@ -125,6 +126,9 @@ export async function GET(request: NextRequest) {
           "video",
         );
         savedToDb = Boolean(persisted);
+        if (persisted?.data_url) {
+          responseUrl = persisted.data_url;
+        }
         if (!savedToDb) {
           saveError = "Video save did not persist to the media store.";
           console.error("Video persist failed:", saveError);
@@ -141,7 +145,7 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json({
       done: true,
-      url: videoUrl,
+      url: responseUrl,
       contentItemId,
       savedToDb,
       ...(saveError ? { saveError } : {}),

--- a/app/components/StudentContentRatingView.tsx
+++ b/app/components/StudentContentRatingView.tsx
@@ -3,18 +3,15 @@
 import { useCallback, useEffect, useState } from "react";
 import type { UserContext } from "@/lib/auth";
 import type { ContentItem, TextMode } from "@/lib/types";
+import {
+  buildPublishedContentState,
+  type MediaRecordResponse,
+  type PublishedItemResponse,
+  type SharedContentMedia,
+} from "@/lib/published-content";
 
 type Props = {
   user: UserContext;
-};
-
-type PublishedItem = {
-  content_item_id: string;
-  content_json: string;
-  media?: {
-    image?: string;
-    video?: string;
-  };
 };
 
 const RATING_LABELS = ["", "Not engaging", "Slightly engaging", "Moderately engaging", "Very engaging", "Extremely engaging"];
@@ -35,7 +32,7 @@ const getContentModeLabels = (item: ContentItem) => {
 
 export default function StudentContentRatingView({ user }: Props) {
   const [contentItems, setContentItems] = useState<ContentItem[]>([]);
-  const [media, setMedia] = useState<Record<string, { image?: string; video?: string }>>({});
+  const [media, setMedia] = useState<Record<string, SharedContentMedia>>({});
   const [ratings, setRatings] = useState<Record<string, number>>({});
   const [savedRatings, setSavedRatings] = useState<Record<string, number>>({});
   const [loading, setLoading] = useState(true);
@@ -45,71 +42,110 @@ export default function StudentContentRatingView({ user }: Props) {
   const classId = user.classId;
   const assignmentId = user.assignmentId;
 
-  const loadContent = useCallback(async () => {
+  const loadPublishedContent = useCallback(async (silent = false) => {
     if (!classId || !assignmentId) {
-      setLoading(false);
+      if (!silent) {
+        setLoading(false);
+      }
+      return;
+    }
+
+    if (!silent) {
+      setLoading(true);
+    }
+
+    try {
+      const [pubRes, mediaRes] = await Promise.all([
+        fetch(
+          `/api/content-publish?classId=${encodeURIComponent(classId)}&assignmentId=${encodeURIComponent(assignmentId)}`,
+        ),
+        fetch(
+          `/api/media?classId=${encodeURIComponent(classId)}&assignmentId=${encodeURIComponent(assignmentId)}&studentId=cohort`,
+        ),
+      ]);
+
+      if (!pubRes.ok) {
+        throw new Error("Failed to load content.");
+      }
+
+      const pubData = (await pubRes.json()) as { items?: PublishedItemResponse[] };
+      const mediaData = mediaRes.ok
+        ? ((await mediaRes.json()) as { results?: MediaRecordResponse[] })
+        : { results: [] };
+      const publishedState = buildPublishedContentState(
+        pubData.items ?? [],
+        mediaData.results ?? [],
+      );
+
+      setContentItems(publishedState.contentItems);
+      setMedia(publishedState.mediaByItemId);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load content.");
+    } finally {
+      if (!silent) {
+        setLoading(false);
+      }
+    }
+  }, [assignmentId, classId]);
+
+  const loadRatings = useCallback(async () => {
+    if (!classId || !assignmentId) {
       return;
     }
 
     try {
-      // Fetch published content
-      const pubRes = await fetch(
-        `/api/content-publish?classId=${encodeURIComponent(classId)}&assignmentId=${encodeURIComponent(assignmentId)}`,
-      );
-      const pubData = await pubRes.json();
-      const items: PublishedItem[] = pubData.items ?? [];
-
-      const parsed: ContentItem[] = items.map((item) => {
-        try {
-          return JSON.parse(item.content_json) as ContentItem;
-        } catch {
-          return {
-            id: item.content_item_id,
-            type: "unknown",
-            title: "Content",
-            body: "",
-            strategy: "",
-          };
-        }
-      });
-      setContentItems(parsed);
-
-      const mediaMap = items.reduce<Record<string, { image?: string; video?: string }>>((accumulator, item) => {
-        if (!item.media) {
-          return accumulator;
-        }
-
-        accumulator[item.content_item_id] = {
-          ...(item.media.image ? { image: item.media.image } : {}),
-          ...(item.media.video ? { video: item.media.video } : {}),
-        };
-        return accumulator;
-      }, {});
-      setMedia(mediaMap);
-
-      // Fetch existing ratings
       const ratingRes = await fetch(
         `/api/content-rating?classId=${encodeURIComponent(classId)}&assignmentId=${encodeURIComponent(assignmentId)}&studentId=${encodeURIComponent(user.userId)}`,
       );
-      if (ratingRes.ok) {
-        const ratingData = await ratingRes.json();
-        const existing: Record<string, number> = {};
-        for (const r of ratingData.ratings ?? []) {
-          existing[r.content_item_id] = r.rating;
-        }
-        setRatings(existing);
-        setSavedRatings(existing);
+      if (!ratingRes.ok) {
+        return;
       }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load content.");
-    } finally {
-      setLoading(false);
+
+      const ratingData = await ratingRes.json();
+      const existing: Record<string, number> = {};
+      for (const r of ratingData.ratings ?? []) {
+        existing[r.content_item_id] = r.rating;
+      }
+      setRatings(existing);
+      setSavedRatings(existing);
+    } catch {
+      // Rating history is best-effort and should not block content rendering.
     }
-  }, [classId, assignmentId, user.userId]);
+  }, [assignmentId, classId, user.userId]);
 
   useEffect(() => {
-    loadContent();
-  }, [loadContent]);
+    void Promise.all([
+      loadPublishedContent(),
+      loadRatings(),
+    ]);
+  }, [loadPublishedContent, loadRatings]);
+
+  useEffect(() => {
+    if (!classId || !assignmentId) {
+      return;
+    }
+
+    const refreshContent = () => {
+      void loadPublishedContent(true);
+    };
+
+    const intervalId = window.setInterval(refreshContent, 15000);
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        refreshContent();
+      }
+    };
+
+    window.addEventListener("focus", refreshContent);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      window.clearInterval(intervalId);
+      window.removeEventListener("focus", refreshContent);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [assignmentId, classId, loadPublishedContent]);
 
   const submitRating = async (contentItemId: string, rating: number) => {
     if (!classId || !assignmentId) return;

--- a/lib/published-content.ts
+++ b/lib/published-content.ts
@@ -1,0 +1,173 @@
+import type { ContentItem, TextMode } from "@/lib/types";
+
+export type SharedContentMedia = {
+  image?: string;
+  video?: string;
+};
+
+export type PublishedItemResponse = {
+  content_item_id: string;
+  content_json: string;
+  media?: SharedContentMedia;
+};
+
+export type MediaRecordResponse = {
+  content_item_id?: string;
+  media_type?: "image" | "video";
+  data_url?: string;
+};
+
+const TEXT_MODES: readonly TextMode[] = [
+  "questions",
+  "phenomenon",
+  "dialogue",
+];
+
+const isTextMode = (value: unknown): value is TextMode =>
+  typeof value === "string" &&
+  (TEXT_MODES as readonly string[]).includes(value);
+
+const normalizeMediaUrl = (value: unknown) => {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+};
+
+const normalizeSharedMedia = (value: unknown): SharedContentMedia | undefined => {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+
+  const media = value as {
+    image?: unknown;
+    video?: unknown;
+  };
+  const image = normalizeMediaUrl(media.image);
+  const video = normalizeMediaUrl(media.video);
+
+  if (!image && !video) {
+    return undefined;
+  }
+
+  return {
+    ...(image ? { image } : {}),
+    ...(video ? { video } : {}),
+  };
+};
+
+const fallbackContentItem = (id: string): ContentItem => ({
+  id,
+  type: "unknown",
+  title: "Content",
+  body: "",
+  strategy: "",
+});
+
+type ParsedContentItem = Partial<ContentItem> & {
+  media?: SharedContentMedia;
+};
+
+const parsePublishedContentItem = (item: PublishedItemResponse) => {
+  const fallback = fallbackContentItem(item.content_item_id);
+
+  try {
+    const parsed = JSON.parse(item.content_json) as ParsedContentItem;
+    const type =
+      typeof parsed.type === "string" && parsed.type.trim()
+        ? parsed.type
+        : fallback.type;
+    const title =
+      typeof parsed.title === "string" && parsed.title.trim()
+        ? parsed.title
+        : fallback.title;
+    const body =
+      typeof parsed.body === "string" ? parsed.body : fallback.body;
+    const strategy =
+      typeof parsed.strategy === "string"
+        ? parsed.strategy
+        : fallback.strategy;
+    const textModes = Array.isArray(parsed.textModes)
+      ? parsed.textModes.filter(isTextMode)
+      : [];
+    const visualBrief =
+      typeof parsed.visualBrief === "string" && parsed.visualBrief.trim()
+        ? parsed.visualBrief
+        : undefined;
+
+    return {
+      contentItem: {
+        id: item.content_item_id,
+        type,
+        title,
+        body,
+        strategy,
+        ...(textModes.length > 0 ? { textModes } : {}),
+        ...(visualBrief ? { visualBrief } : {}),
+      } satisfies ContentItem,
+      embeddedMedia: normalizeSharedMedia(parsed.media),
+    };
+  } catch {
+    return { contentItem: fallback, embeddedMedia: undefined };
+  }
+};
+
+const buildDirectMediaMap = (
+  mediaRecords: MediaRecordResponse[],
+): Record<string, SharedContentMedia> =>
+  mediaRecords.reduce<Record<string, SharedContentMedia>>((accumulator, record) => {
+    const contentItemId = record.content_item_id;
+    const mediaUrl = normalizeMediaUrl(record.data_url);
+
+    if (!contentItemId || !mediaUrl) {
+      return accumulator;
+    }
+
+    if (!accumulator[contentItemId]) {
+      accumulator[contentItemId] = {};
+    }
+
+    if (record.media_type === "image") {
+      accumulator[contentItemId].image = mediaUrl;
+    }
+
+    if (record.media_type === "video") {
+      accumulator[contentItemId].video = mediaUrl;
+    }
+
+    return accumulator;
+  }, {});
+
+export const buildPublishedContentState = (
+  items: PublishedItemResponse[],
+  mediaRecords: MediaRecordResponse[],
+) => {
+  const directMediaByItemId = buildDirectMediaMap(mediaRecords);
+
+  const entries = items.map((item) => {
+    const { contentItem, embeddedMedia } = parsePublishedContentItem(item);
+    const mergedMedia = {
+      ...(embeddedMedia ?? {}),
+      ...(normalizeSharedMedia(item.media) ?? {}),
+      ...(directMediaByItemId[item.content_item_id] ?? {}),
+    };
+
+    return {
+      contentItem,
+      media:
+        Object.keys(mergedMedia).length > 0 ? mergedMedia : undefined,
+    };
+  });
+
+  return {
+    contentItems: entries.map((entry) => entry.contentItem),
+    mediaByItemId: entries.reduce<Record<string, SharedContentMedia>>(
+      (accumulator, entry) => {
+        if (entry.media) {
+          accumulator[entry.contentItem.id] = entry.media;
+        }
+        return accumulator;
+      },
+      {},
+    ),
+  };
+};


### PR DESCRIPTION
## Summary
- merge published content with direct cohort media records on the student rating screen so image-only, video-only, and mixed-media items render reliably
- canonicalize student content IDs and add a small shared helper with regression tests for published-content/media merging
- return the persisted video URL from the video status endpoint instead of the transient upstream URL so published videos use the shareable stored asset

## Why this fixes the bug
- the student screen previously trusted only the `/api/content-publish` payload once, so if media was omitted there or arrived slightly later, the student never recovered and rendered text-only cards
- the video polling route returned the upstream x.ai URL even after saving a stable copy, which made the publish flow depend on a transient video URL instead of the stored asset

## Testing
- `npm test`
- `npm test -- __tests__/lib/published-content.test.ts __tests__/api/engagement-video-status.test.ts __tests__/api/content-publish.test.ts`

## Notes
- `npm run lint` still reports a pre-existing `react-hooks/set-state-in-effect` error in `app/components/AuthContext.tsx:180`; this PR does not change that file