### PR TITLE
Fix cohort retry state and soft-invalidate reanalysis cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,9 @@ Recommended worker configuration:
 
 - Environment variables: `OPENAI_API_KEY`, `DYNAMODB_TABLE`, and either
   `ENGAGE_AWS_REGION` or the default Lambda `AWS_REGION`
+- Optional retry alignment: `COHORT_ANALYSIS_QUEUE_MAX_RECEIVE_COUNT` if you
+  want the worker's final-failure threshold to match a non-default SQS
+  `maxReceiveCount` (defaults to `3`)
 - Optional local/non-role credentials:
   `ENGAGE_AWS_ACCESS_KEY_ID` and `ENGAGE_AWS_SECRET_ACCESS_KEY`
 - IAM permissions for DynamoDB reads/writes on the app table plus standard

--- a/__tests__/api/strategy-batch.test.ts
+++ b/__tests__/api/strategy-batch.test.ts
@@ -30,23 +30,41 @@ vi.mock("openai", () => {
 
 vi.mock("@/lib/nosql", () => {
   const cache = new Map<string, string>();
+  const invalidated = new Set<string>();
+  const getKey = (classId: string, assignmentId: string, studentId: string) =>
+    `${classId}:${assignmentId}:${studentId}`;
 
   return {
     getCachedPlanJson: vi.fn(async (classId: string, assignmentId: string, studentId: string) => {
-      return cache.get(`${classId}:${assignmentId}:${studentId}`) ?? null;
+      const key = getKey(classId, assignmentId, studentId);
+      if (invalidated.has(key)) {
+        return null;
+      }
+      return cache.get(key) ?? null;
+    }),
+    invalidateCachedPlanJson: vi.fn(async (classId: string, assignmentId: string, studentId: string) => {
+      const key = getKey(classId, assignmentId, studentId);
+      if (cache.has(key)) {
+        invalidated.add(key);
+      }
+      return cache.has(key);
     }),
     upsertCachedPlanJson: vi.fn(async (classId: string, assignmentId: string, studentId: string, planJson: string) => {
-      cache.set(`${classId}:${assignmentId}:${studentId}`, planJson);
+      const key = getKey(classId, assignmentId, studentId);
+      invalidated.delete(key);
+      cache.set(key, planJson);
     }),
     __resetCache: () => {
       cache.clear();
+      invalidated.clear();
     },
   };
 });
 
 const { POST } = await import("@/app/api/strategy-batch/route");
-const { __resetCache } = (await import("@/lib/nosql")) as unknown as {
+const { __resetCache, invalidateCachedPlanJson } = (await import("@/lib/nosql")) as unknown as {
   __resetCache: () => void;
+  invalidateCachedPlanJson: ReturnType<typeof vi.fn>;
 };
 
 const buildRequest = (
@@ -68,6 +86,7 @@ const buildRequest = (
 beforeEach(() => {
   process.env.OPENAI_API_KEY = "test-key";
   createCompletion.mockReset();
+  invalidateCachedPlanJson.mockReset();
   __resetCache();
 });
 
@@ -253,6 +272,11 @@ describe("POST /api/strategy-batch", () => {
     ], { forceRefresh: true }));
 
     expect(secondRes.status).toBe(200);
+    expect(invalidateCachedPlanJson).toHaveBeenCalledWith(
+      "class-1",
+      "assignment-1",
+      "student-1",
+    );
     expect(createCompletion).toHaveBeenCalledTimes(1);
 
     const data = await secondRes.json();

--- a/__tests__/api/strategy-batch.test.ts
+++ b/__tests__/api/strategy-batch.test.ts
@@ -255,6 +255,7 @@ describe("POST /api/strategy-batch", () => {
     ]));
 
     expect(firstRes.status).toBe(200);
+    expect(invalidateCachedPlanJson).not.toHaveBeenCalled();
     expect(createCompletion).toHaveBeenCalledTimes(1);
 
     createCompletion.mockReset();

--- a/__tests__/api/strategy-job.test.ts
+++ b/__tests__/api/strategy-job.test.ts
@@ -265,6 +265,68 @@ describe("GET /api/strategy-job/[jobId]", () => {
         error: "Request timed out.",
       },
     ]);
+    expect(data.retrying).toEqual([]);
+    expect(data.distribution).toEqual({ analogy: 1 });
+  });
+
+  it("returns retrying students separately from final failures", async () => {
+    getCohortJob.mockResolvedValue({
+      job: {
+        job_id: "job-456",
+        class_id: "class-1",
+        assignment_id: "assignment-1",
+        total_students: 2,
+        processed_students: 1,
+        completed_students: 1,
+        failed_students: 0,
+        status: "running",
+        error_message: undefined,
+        created_at: "2026-03-25T00:00:00.000Z",
+        updated_at: "2026-03-25T00:00:45.000Z",
+      },
+      students: [
+        {
+          job_id: "job-456",
+          class_id: "class-1",
+          assignment_id: "assignment-1",
+          student_id: "student-1",
+          student_name: "Ava",
+          status: "completed",
+          source: "model",
+          plan_json: JSON.stringify({
+            strategy: "Analogy",
+            summary: "Use analogy.",
+          }),
+          updated_at: "2026-03-25T00:00:30.000Z",
+        },
+        {
+          job_id: "job-456",
+          class_id: "class-1",
+          assignment_id: "assignment-1",
+          student_id: "student-2",
+          student_name: "Jon",
+          status: "retrying",
+          error: "Strategy generation timed out before the model returned.",
+          updated_at: "2026-03-25T00:00:45.000Z",
+        },
+      ],
+    });
+
+    const res = await GET(
+      new Request("http://localhost:3000/api/strategy-job/job-456"),
+      { params: Promise.resolve({ jobId: "job-456" }) },
+    );
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.errors).toEqual([]);
+    expect(data.retrying).toEqual([
+      {
+        id: "student-2",
+        name: "Jon",
+        error: "Strategy generation timed out before the model returned.",
+      },
+    ]);
     expect(data.distribution).toEqual({ analogy: 1 });
   });
 });

--- a/__tests__/api/strategy-job.test.ts
+++ b/__tests__/api/strategy-job.test.ts
@@ -5,6 +5,7 @@ const {
   enqueueCohortJobStudents,
   getCohortAnalysisQueueConfigIssues,
   getCohortJob,
+  invalidateCachedPlanJson,
   isCohortAnalysisQueueConfigured,
   setCohortJobStatus,
   randomUUID,
@@ -13,6 +14,7 @@ const {
   enqueueCohortJobStudents: vi.fn(),
   getCohortAnalysisQueueConfigIssues: vi.fn(),
   getCohortJob: vi.fn(),
+  invalidateCachedPlanJson: vi.fn(),
   isCohortAnalysisQueueConfigured: vi.fn(),
   setCohortJobStatus: vi.fn(),
   randomUUID: vi.fn(() => "job-123"),
@@ -33,6 +35,7 @@ vi.mock("@/lib/cohort-analysis-queue", () => ({
 vi.mock("@/lib/nosql", () => ({
   createCohortJob,
   getCohortJob,
+  invalidateCachedPlanJson,
   setCohortJobStatus,
 }));
 
@@ -44,6 +47,7 @@ beforeEach(() => {
   enqueueCohortJobStudents.mockReset();
   getCohortAnalysisQueueConfigIssues.mockReset();
   getCohortJob.mockReset();
+  invalidateCachedPlanJson.mockReset();
   isCohortAnalysisQueueConfigured.mockReset();
   setCohortJobStatus.mockReset();
   randomUUID.mockClear();
@@ -53,6 +57,7 @@ describe("POST /api/strategy-job", () => {
   it("creates a cohort job and enqueues uncached students", async () => {
     isCohortAnalysisQueueConfigured.mockReturnValue(true);
     createCohortJob.mockResolvedValue(undefined);
+    invalidateCachedPlanJson.mockResolvedValue(false);
     enqueueCohortJobStudents.mockResolvedValue(undefined);
 
     const res = await POST(
@@ -85,6 +90,7 @@ describe("POST /api/strategy-job", () => {
       "assignment-1",
       2,
     );
+    expect(invalidateCachedPlanJson).not.toHaveBeenCalled();
     expect(enqueueCohortJobStudents).toHaveBeenCalledWith({
       jobId: "job-123",
       classId: "class-1",
@@ -102,6 +108,7 @@ describe("POST /api/strategy-job", () => {
   it("passes forceRefresh through to the queue payload", async () => {
     isCohortAnalysisQueueConfigured.mockReturnValue(true);
     createCohortJob.mockResolvedValue(undefined);
+    invalidateCachedPlanJson.mockResolvedValue(true);
     enqueueCohortJobStudents.mockResolvedValue(undefined);
 
     const res = await POST(
@@ -121,6 +128,11 @@ describe("POST /api/strategy-job", () => {
     );
 
     expect(res.status).toBe(201);
+    expect(invalidateCachedPlanJson).toHaveBeenCalledWith(
+      "class-1",
+      "assignment-1",
+      "student-1",
+    );
     expect(enqueueCohortJobStudents).toHaveBeenCalledWith({
       jobId: "job-123",
       classId: "class-1",

--- a/__tests__/lib/strategy-plan-cache.test.ts
+++ b/__tests__/lib/strategy-plan-cache.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  deserializeCachedPlan,
+  invalidateSerializedCachedPlan,
+  serializeCachedPlan,
+} from "@/lib/strategy-plan-cache";
+
+describe("strategy-plan-cache invalidation", () => {
+  it("treats invalidated cache envelopes as cache misses", () => {
+    const valid = serializeCachedPlan(
+      {
+        strategy: "analogy",
+        summary: "Use analogy.",
+      },
+      2,
+    );
+
+    expect(
+      deserializeCachedPlan(valid, {
+        lessonNumber: 2,
+        requireVersionMatch: true,
+      }),
+    ).toEqual({
+      strategy: "analogy",
+      summary: "Use analogy.",
+    });
+
+    const invalidated = invalidateSerializedCachedPlan(
+      valid,
+      "2026-03-27T00:00:00.000Z",
+    );
+
+    expect(
+      deserializeCachedPlan(invalidated, {
+        lessonNumber: 2,
+        requireVersionMatch: true,
+      }),
+    ).toBeNull();
+  });
+
+  it("can soft-invalidate legacy cached plan payloads without deleting the plan", () => {
+    const invalidated = invalidateSerializedCachedPlan(
+      JSON.stringify({
+        strategy: "cognitive conflict",
+        summary: "Use the misconception directly.",
+      }),
+      "2026-03-27T00:00:00.000Z",
+    );
+
+    const parsed = JSON.parse(invalidated) as {
+      promptVersion: number;
+      invalidatedAt: string;
+      plan: {
+        strategy: string;
+        summary: string;
+      };
+    };
+
+    expect(parsed.invalidatedAt).toBe("2026-03-27T00:00:00.000Z");
+    expect(parsed.plan).toEqual({
+      strategy: "cognitive conflict",
+      summary: "Use the misconception directly.",
+    });
+    expect(deserializeCachedPlan(invalidated)).toBeNull();
+  });
+});

--- a/__tests__/workers/cohort-analysis-worker.test.ts
+++ b/__tests__/workers/cohort-analysis-worker.test.ts
@@ -1,0 +1,86 @@
+import { afterAll, describe, expect, it } from "vitest";
+
+const originalDynamoTable = process.env.DYNAMODB_TABLE;
+const originalOpenAiKey = process.env.OPENAI_API_KEY;
+const originalQueueMaxReceiveCount =
+  process.env.COHORT_ANALYSIS_QUEUE_MAX_RECEIVE_COUNT;
+
+process.env.DYNAMODB_TABLE = "test-table";
+process.env.OPENAI_API_KEY = "test-key";
+delete process.env.COHORT_ANALYSIS_QUEUE_MAX_RECEIVE_COUNT;
+
+const {
+  getApproximateReceiveCount,
+  getJobCounterDeltas,
+  getMaxReceiveCount,
+  isFinalReceiveAttempt,
+} = await import("../../workers/cohort-analysis-worker/index.mjs");
+
+afterAll(() => {
+  if (originalDynamoTable === undefined) {
+    delete process.env.DYNAMODB_TABLE;
+  } else {
+    process.env.DYNAMODB_TABLE = originalDynamoTable;
+  }
+
+  if (originalOpenAiKey === undefined) {
+    delete process.env.OPENAI_API_KEY;
+  } else {
+    process.env.OPENAI_API_KEY = originalOpenAiKey;
+  }
+
+  if (originalQueueMaxReceiveCount === undefined) {
+    delete process.env.COHORT_ANALYSIS_QUEUE_MAX_RECEIVE_COUNT;
+  } else {
+    process.env.COHORT_ANALYSIS_QUEUE_MAX_RECEIVE_COUNT =
+      originalQueueMaxReceiveCount;
+  }
+});
+
+describe("cohort-analysis worker retry helpers", () => {
+  it("does not count retrying attempts as processed students", () => {
+    expect(getJobCounterDeltas(null, "retrying")).toEqual({
+      processedDelta: 0,
+      completedDelta: 0,
+      failedDelta: 0,
+    });
+    expect(getJobCounterDeltas("retrying", "completed")).toEqual({
+      processedDelta: 1,
+      completedDelta: 1,
+      failedDelta: 0,
+    });
+    expect(getJobCounterDeltas("retrying", "failed")).toEqual({
+      processedDelta: 1,
+      completedDelta: 0,
+      failedDelta: 1,
+    });
+  });
+
+  it("keeps terminal student statuses idempotent", () => {
+    expect(getJobCounterDeltas("completed", "completed")).toEqual({
+      processedDelta: 0,
+      completedDelta: 0,
+      failedDelta: 0,
+    });
+    expect(getJobCounterDeltas("failed", "failed")).toEqual({
+      processedDelta: 0,
+      completedDelta: 0,
+      failedDelta: 0,
+    });
+  });
+
+  it("classifies final receive attempts from SQS receive counts", () => {
+    expect(getMaxReceiveCount()).toBe(3);
+    expect(
+      getApproximateReceiveCount({
+        attributes: { ApproximateReceiveCount: "2" },
+      }),
+    ).toBe(2);
+    expect(isFinalReceiveAttempt({ attributes: { ApproximateReceiveCount: "2" } }, 3)).toBe(
+      false,
+    );
+    expect(isFinalReceiveAttempt({ attributes: { ApproximateReceiveCount: "3" } }, 3)).toBe(
+      true,
+    );
+  });
+});

--- a/app/api/strategy-batch/route.ts
+++ b/app/api/strategy-batch/route.ts
@@ -7,7 +7,11 @@ import {
   type LessonGenerationContext,
   type ResolvedQuizEvidence,
 } from "@/lib/lesson-context";
-import { getCachedPlanJson, upsertCachedPlanJson } from "@/lib/nosql";
+import {
+  getCachedPlanJson,
+  invalidateCachedPlanJson,
+  upsertCachedPlanJson,
+} from "@/lib/nosql";
 import {
   deserializeCachedPlan,
   serializeCachedPlan,
@@ -267,6 +271,14 @@ export async function POST(request: Request) {
     const shouldForceRefresh = forceRefresh === true;
     const results: StudentStrategyResult[] = [];
     const errors: StudentStrategyError[] = [];
+
+    if (shouldForceRefresh) {
+      await Promise.all(
+        students.map((student) =>
+          invalidateCachedPlanJson(classKey, assignmentKey, student.id),
+        ),
+      );
+    }
 
     const studentChunks = chunkItems(students, STRATEGY_BATCH_CONCURRENCY);
     for (const studentChunk of studentChunks) {

--- a/app/api/strategy-job/[jobId]/route.ts
+++ b/app/api/strategy-job/[jobId]/route.ts
@@ -60,6 +60,14 @@ export async function GET(
       error: student.error ?? "Failed to analyze student.",
     }));
 
+  const retrying = data.students
+    .filter((student) => student.status === "retrying")
+    .map((student) => ({
+      id: student.student_id,
+      name: student.student_name,
+      error: student.error ?? "Retrying student analysis.",
+    }));
+
   const distribution: Record<string, number> = {};
   results.forEach((result) => {
     if (!result.plan.strategy || typeof result.plan.strategy !== "string") {
@@ -85,6 +93,7 @@ export async function GET(
     },
     results,
     errors,
+    retrying,
     distribution,
   });
 }

--- a/app/api/strategy-job/route.ts
+++ b/app/api/strategy-job/route.ts
@@ -7,7 +7,11 @@ import {
   getCohortAnalysisQueueConfigIssues,
   isCohortAnalysisQueueConfigured,
 } from "@/lib/cohort-analysis-queue";
-import { createCohortJob, setCohortJobStatus } from "@/lib/nosql";
+import {
+  createCohortJob,
+  invalidateCachedPlanJson,
+  setCohortJobStatus,
+} from "@/lib/nosql";
 
 type Student = {
   id: string;
@@ -82,6 +86,14 @@ export async function POST(request: Request) {
     );
 
     try {
+      if (shouldForceRefresh) {
+        await Promise.all(
+          normalizedStudents.map((student) =>
+            invalidateCachedPlanJson(classKey, assignmentKey, student.id),
+          ),
+        );
+      }
+
       await enqueueCohortJobStudents({
         jobId,
         classId: classKey,

--- a/app/components/TeacherView.tsx
+++ b/app/components/TeacherView.tsx
@@ -1243,7 +1243,7 @@ export default function TeacherView({ user }: Props) {
       total: studentAnswers.length,
       currentName: forceRefresh
         ? "Starting cohort reanalysis..."
-        : "Loading cache...",
+        : "Evaluating cached students...",
     });
 
     try {

--- a/app/components/TeacherView.tsx
+++ b/app/components/TeacherView.tsx
@@ -71,6 +71,7 @@ type StrategyJobStatusResponse = {
   };
   results?: StudentStrategyResult[];
   errors?: Array<{ id?: string; name?: string; error?: string }>;
+  retrying?: Array<{ id?: string; name?: string; error?: string }>;
   distribution?: Record<string, number>;
   error?: string;
 };
@@ -1366,6 +1367,15 @@ export default function TeacherView({ user }: Props) {
             const processedStudents = statusData.job.processedStudents ?? 0;
             const queuedStudents = statusData.job.totalStudents ?? uncachedStudents.length;
             const terminal = isTerminalCohortJobStatus(statusData.job.status);
+            const retryingStudents = (statusData.retrying ?? [])
+              .map((student) => student.name)
+              .filter((name): name is string => Boolean(name));
+            const retryingLabel =
+              retryingStudents.length === 1
+                ? `Waiting to retry ${retryingStudents[0]}...`
+                : retryingStudents.length > 1
+                  ? `Waiting to retry ${retryingStudents.length} students...`
+                  : null;
 
             setCohortProgress({
               processed: Math.min(
@@ -1379,6 +1389,8 @@ export default function TeacherView({ user }: Props) {
                   ? forceRefresh
                     ? `Queued ${queuedStudents} student${queuedStudents === 1 ? "" : "s"} for reanalysis...`
                     : `Queued ${queuedStudents} uncached student${queuedStudents === 1 ? "" : "s"} for analysis...`
+                  : retryingLabel
+                    ? retryingLabel
                   : forceRefresh
                     ? `Reanalyzing ${processedStudents} of ${queuedStudents} student${queuedStudents === 1 ? "" : "s"}...`
                     : `Analyzing ${processedStudents} of ${queuedStudents} uncached student${queuedStudents === 1 ? "" : "s"}...`,

--- a/lib/nosql.ts
+++ b/lib/nosql.ts
@@ -12,6 +12,8 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 
+import { invalidateSerializedCachedPlan } from "@/lib/strategy-plan-cache";
+
 const DYNAMODB_MAX_ITEM_BYTES = 400_000;
 
 type StrategyCacheRecord = {
@@ -348,6 +350,29 @@ export const upsertCachedPlanJson = async (
     };
     await persistStore(store);
   });
+};
+
+export const invalidateCachedPlanJson = async (
+  classId: string,
+  assignmentId: string,
+  studentId: string,
+) => {
+  const existingPlanJson = await getCachedPlanJson(
+    classId,
+    assignmentId,
+    studentId,
+  );
+  if (!existingPlanJson) {
+    return false;
+  }
+
+  await upsertCachedPlanJson(
+    classId,
+    assignmentId,
+    studentId,
+    invalidateSerializedCachedPlan(existingPlanJson),
+  );
+  return true;
 };
 
 export type CachedPlanRecord = {

--- a/lib/nosql.ts
+++ b/lib/nosql.ts
@@ -91,7 +91,7 @@ export type CohortJobStudentRecord = {
   assignment_id: string;
   student_id: string;
   student_name: string;
-  status: "completed" | "failed";
+  status: "completed" | "failed" | "retrying";
   source?: "cache" | "model" | null;
   plan_json?: string;
   timing?: Record<string, unknown>;

--- a/lib/strategy-plan-cache.ts
+++ b/lib/strategy-plan-cache.ts
@@ -3,11 +3,17 @@ const STRATEGY_PLAN_CACHE_VERSION = 2;
 type CachedPlanEnvelope<TPlan> = {
   promptVersion: number;
   lessonNumber: number | null;
+  invalidatedAt?: string | null;
   plan: TPlan;
 };
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
+
+const isCachedPlanEnvelope = <TPlan>(
+  value: unknown,
+): value is CachedPlanEnvelope<TPlan> =>
+  isRecord(value) && "promptVersion" in value && "plan" in value;
 
 export const serializeCachedPlan = <TPlan>(
   plan: TPlan,
@@ -19,6 +25,27 @@ export const serializeCachedPlan = <TPlan>(
     plan,
   } satisfies CachedPlanEnvelope<TPlan>);
 
+export const invalidateSerializedCachedPlan = (
+  planJson: string,
+  invalidatedAt = new Date().toISOString(),
+) => {
+  const parsed = JSON.parse(planJson) as unknown;
+
+  if (isCachedPlanEnvelope(parsed)) {
+    return JSON.stringify({
+      ...parsed,
+      invalidatedAt,
+    } satisfies CachedPlanEnvelope<unknown>);
+  }
+
+  return JSON.stringify({
+    promptVersion: STRATEGY_PLAN_CACHE_VERSION,
+    lessonNumber: null,
+    invalidatedAt,
+    plan: parsed,
+  } satisfies CachedPlanEnvelope<unknown>);
+};
+
 export const deserializeCachedPlan = <TPlan>(
   planJson: string,
   options?: {
@@ -28,14 +55,14 @@ export const deserializeCachedPlan = <TPlan>(
 ): TPlan | null => {
   const parsed = JSON.parse(planJson) as unknown;
 
-  if (
-    isRecord(parsed) &&
-    "promptVersion" in parsed &&
-    "plan" in parsed
-  ) {
+  if (isCachedPlanEnvelope<TPlan>(parsed)) {
     const promptVersion =
       typeof parsed.promptVersion === "number" ? parsed.promptVersion : null;
     if (promptVersion !== STRATEGY_PLAN_CACHE_VERSION) {
+      return null;
+    }
+
+    if (typeof parsed.invalidatedAt === "string" && parsed.invalidatedAt.length > 0) {
       return null;
     }
 

--- a/workers/cohort-analysis-worker/index.mjs
+++ b/workers/cohort-analysis-worker/index.mjs
@@ -12,6 +12,7 @@ import OpenAI, { APIConnectionTimeoutError } from "openai";
 
 const STRATEGY_REQUEST_TIMEOUT_MS = 45_000;
 const STRATEGY_PLAN_CACHE_VERSION = 2;
+const DEFAULT_QUEUE_MAX_RECEIVE_COUNT = 3;
 
 const workerDir = path.dirname(fileURLToPath(import.meta.url));
 const lessonDataDir = path.join(workerDir, "data");
@@ -297,6 +298,36 @@ const openai = new OpenAI({
   maxRetries: 0,
 });
 
+const isTerminalStudentStatus = (status) => status === "completed" || status === "failed";
+
+const isProcessedStudentStatus = (status) => isTerminalStudentStatus(status);
+
+export const getJobCounterDeltas = (previousStatus, nextStatus) => ({
+  processedDelta:
+    Number(isProcessedStudentStatus(nextStatus)) -
+    Number(isProcessedStudentStatus(previousStatus)),
+  completedDelta: Number(nextStatus === "completed") - Number(previousStatus === "completed"),
+  failedDelta: Number(nextStatus === "failed") - Number(previousStatus === "failed"),
+});
+
+export const getApproximateReceiveCount = (record) => {
+  const parsed = Number(record?.attributes?.ApproximateReceiveCount ?? 1);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : 1;
+};
+
+export const getMaxReceiveCount = () => {
+  const parsed = Number(
+    process.env.COHORT_ANALYSIS_QUEUE_MAX_RECEIVE_COUNT ??
+      DEFAULT_QUEUE_MAX_RECEIVE_COUNT,
+  );
+  return Number.isInteger(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_QUEUE_MAX_RECEIVE_COUNT;
+};
+
+export const isFinalReceiveAttempt = (record, maxReceiveCount = getMaxReceiveCount()) =>
+  getApproximateReceiveCount(record) >= maxReceiveCount;
+
 const getCachedPlanJson = async (classId, assignmentId, studentId) => {
   const result = await dynamo.send(
     new GetCommand({
@@ -331,15 +362,50 @@ const upsertCachedPlanJson = async (classId, assignmentId, studentId, planJson) 
 
 const jobPk = (jobId) => `JOB#${jobId}`;
 
+const getStudentResultStatus = async (jobId, studentId) => {
+  const result = await dynamo.send(
+    new GetCommand({
+      TableName: tableName,
+      Key: {
+        class_id: jobPk(jobId),
+        record_id: `STUDENT#${studentId}`,
+      },
+    }),
+  );
+
+  const status = result.Item?.status;
+  return typeof status === "string" ? status : null;
+};
+
 const updateJobMeta = async ({
   jobId,
   classId,
   assignmentId,
   totalStudents,
-  completedDelta,
-  failedDelta,
+  previousStatus = null,
+  nextStatus,
 }) => {
+  const { processedDelta, completedDelta, failedDelta } = getJobCounterDeltas(
+    previousStatus,
+    nextStatus,
+  );
   const timestamp = nowIso();
+  const expressionAttributeValues = {
+    ":recordType": "cohort_job",
+    ":classId": classId,
+    ":assignmentId": assignmentId,
+    ":totalStudents": totalStudents,
+    ":createdAt": timestamp,
+    ":updatedAt": timestamp,
+    ":processedDelta": processedDelta,
+    ":completedDelta": completedDelta,
+    ":failedDelta": failedDelta,
+  };
+  const addClauses = [
+    processedDelta !== 0 ? "processed_students :processedDelta" : null,
+    completedDelta !== 0 ? "completed_students :completedDelta" : null,
+    failedDelta !== 0 ? "failed_students :failedDelta" : null,
+  ].filter(Boolean);
   const result = await dynamo.send(
     new UpdateCommand({
       TableName: tableName,
@@ -353,20 +419,8 @@ const updateJobMeta = async ({
           total_students = if_not_exists(total_students, :totalStudents),
           created_at = if_not_exists(created_at, :createdAt),
           updated_at = :updatedAt
-        ADD processed_students :processedDelta,
-          completed_students :completedDelta,
-          failed_students :failedDelta`,
-      ExpressionAttributeValues: {
-        ":recordType": "cohort_job",
-        ":classId": classId,
-        ":assignmentId": assignmentId,
-        ":totalStudents": totalStudents,
-        ":createdAt": timestamp,
-        ":updatedAt": timestamp,
-        ":processedDelta": 1,
-        ":completedDelta": completedDelta,
-        ":failedDelta": failedDelta,
-      },
+        ${addClauses.length > 0 ? `ADD ${addClauses.join(", ")}` : ""}`,
+      ExpressionAttributeValues: expressionAttributeValues,
       ReturnValues: "ALL_NEW",
     }),
   );
@@ -407,7 +461,7 @@ const updateJobMeta = async ({
           "#status": "status",
         },
         ExpressionAttributeValues: {
-          ":status": "running",
+          ":status": nextStatus === "retrying" || processedStudents > 0 ? "running" : "queued",
           ":updatedAt": nowIso(),
         },
       }),
@@ -426,7 +480,7 @@ const putStudentResult = async ({
   timing,
   error,
 }) => {
-  await dynamo.send(
+  const result = await dynamo.send(
     new PutCommand({
       TableName: tableName,
       Item: {
@@ -444,8 +498,12 @@ const putStudentResult = async ({
         error: error ?? undefined,
         updated_at: nowIso(),
       },
+      ReturnValues: "ALL_OLD",
     }),
   );
+
+  const previousStatus = result.Attributes?.status;
+  return typeof previousStatus === "string" ? previousStatus : null;
 };
 
 const normalizeLessonNumber = (value) => {
@@ -507,6 +565,26 @@ const processRecord = async (record) => {
     student,
   } =
     payload;
+  const attemptNumber = getApproximateReceiveCount(record);
+  const maxReceiveCount = getMaxReceiveCount();
+  const finalAttempt = isFinalReceiveAttempt(record, maxReceiveCount);
+
+  const existingStatus = await getStudentResultStatus(jobId, student.id);
+  if (isTerminalStudentStatus(existingStatus)) {
+    console.info(
+      "cohort-analysis-worker duplicate terminal result skipped",
+      JSON.stringify({
+        jobId,
+        classId,
+        assignmentId,
+        studentId: student.id,
+        attemptNumber,
+        maxReceiveCount,
+        existingStatus,
+      }),
+    );
+    return;
+  }
 
   let source = "model";
   let cacheReadMs = 0;
@@ -598,7 +676,7 @@ const processRecord = async (record) => {
       timedOut: false,
     };
 
-    await putStudentResult({
+    const previousStatus = await putStudentResult({
       jobId,
       classId,
       assignmentId,
@@ -614,8 +692,8 @@ const processRecord = async (record) => {
       classId,
       assignmentId,
       totalStudents,
-      completedDelta: 1,
-      failedDelta: 0,
+      previousStatus,
+      nextStatus: "completed",
     });
 
     console.info(
@@ -627,6 +705,8 @@ const processRecord = async (record) => {
         lessonNumber,
         forceRefresh,
         studentId: student.id,
+        attemptNumber,
+        maxReceiveCount,
         source,
         timing,
       }),
@@ -645,13 +725,14 @@ const processRecord = async (record) => {
         : error instanceof Error
           ? error.message
           : "Failed to analyze student.";
+    const nextStatus = finalAttempt ? "failed" : "retrying";
 
-    await putStudentResult({
+    const previousStatus = await putStudentResult({
       jobId: payload.jobId,
       classId: payload.classId,
       assignmentId: payload.assignmentId,
       student: payload.student,
-      status: "failed",
+      status: nextStatus,
       source,
       timing,
       error: message,
@@ -662,8 +743,8 @@ const processRecord = async (record) => {
       classId: payload.classId,
       assignmentId: payload.assignmentId,
       totalStudents: payload.totalStudents,
-      completedDelta: 0,
-      failedDelta: 1,
+      previousStatus,
+      nextStatus,
     });
 
     console.error(
@@ -675,6 +756,10 @@ const processRecord = async (record) => {
         lessonNumber: payload.lessonNumber,
         forceRefresh: payload.forceRefresh,
         studentId: payload.student.id,
+        attemptNumber,
+        maxReceiveCount,
+        finalAttempt,
+        status: nextStatus,
         error: message,
         timing,
       }),

--- a/workers/cohort-analysis-worker/index.mjs
+++ b/workers/cohort-analysis-worker/index.mjs
@@ -229,6 +229,10 @@ const deserializeCachedPlan = (planJson, options = {}) => {
       return null;
     }
 
+    if (typeof parsed.invalidatedAt === "string" && parsed.invalidatedAt.length > 0) {
+      return null;
+    }
+
     if (
       typeof options.lessonNumber === "number" &&
       parsed.lessonNumber !== options.lessonNumber


### PR DESCRIPTION
## Summary
- treat interim Lambda/SQS worker failures as `retrying` until the final receive attempt so the cohort job UI does not report a student as failed too early
- soft-invalidate cached cohort plans when `Reanalyze All` runs by marking cache envelopes as invalid instead of deleting the stored plan record
- surface retrying students in the cohort job status API and show clearer progress text while the queue is waiting to retry
- document the optional `COHORT_ANALYSIS_QUEUE_MAX_RECEIVE_COUNT` setting so the worker's final-failure threshold can stay aligned with the SQS redrive policy

## Why
- after PR #9, the worker could time out once, the UI would show `failed student`, and SQS would still be retrying the message in the background
- `Reanalyze All` already bypassed cache reads, but previous cached results stayed active until a successful rerun overwrote them
- this change keeps the old plan record in DynamoDB while making invalidated cache entries behave like cache misses

## Testing
- `npm test`
- `npm run build`

## Notes
- cached plan records are not deleted; they are soft-invalidated with an `invalidatedAt` marker
- successful reanalysis writes a fresh valid cache envelope back to the same cache key