### PR TITLE
Image debug

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -16,6 +16,7 @@ frontend:
         - echo "ENGAGE_AWS_SECRET_ACCESS_KEY=$ENGAGE_AWS_SECRET_ACCESS_KEY" >> .env.production
         - echo "COHORT_ANALYSIS_QUEUE_URL=$COHORT_ANALYSIS_QUEUE_URL" >> .env.production
         - echo "ENGAGE_S3_BUCKET=$ENGAGE_S3_BUCKET" >> .env.production
+        - echo "OPENAI_IMAGE_MODEL=$OPENAI_IMAGE_MODEL" >> .env.production
         - npm run build
   artifacts:
     baseDirectory: .next

--- a/app/api/engagement-image/route.ts
+++ b/app/api/engagement-image/route.ts
@@ -133,7 +133,7 @@ export async function POST(request: Request) {
       annotatedImageUrl?: string;
     };
 
-    const model = process.env.OPENAI_IMAGE_MODEL ?? "gpt-image-1.5";
+    const model = process.env.OPENAI_IMAGE_MODEL || "gpt-image-1";
     const trimmedRefine = refinementPrompt?.trim().slice(0, MAX_REFINEMENT_PROMPT_LENGTH);
     const isRefine = !!(trimmedRefine && previousImageUrl);
 
@@ -158,7 +158,7 @@ export async function POST(request: Request) {
         image: imageInput,
         prompt: editPrompt,
         size: "1024x1024",
-        quality: "high",
+        quality: "low",
         output_format: "webp",
       });
     } else {
@@ -167,7 +167,7 @@ export async function POST(request: Request) {
         model,
         prompt,
         size: "1024x1024",
-        quality: "high",
+        quality: "low",
         output_format: "webp",
       });
     }

--- a/app/components/TeacherView.tsx
+++ b/app/components/TeacherView.tsx
@@ -418,6 +418,8 @@ export default function TeacherView({ user }: Props) {
     };
   }, []);
 
+
+
   const getStrategyLabel = getEngagementStrategyLabel;
 
   const getStrategyDescription = getEngagementStrategyDescription;

--- a/app/components/TeacherView.tsx
+++ b/app/components/TeacherView.tsx
@@ -1696,7 +1696,7 @@ export default function TeacherView({ user }: Props) {
             });
             const text = await res.text();
             let data: Record<string, unknown>;
-            try { data = JSON.parse(text); } catch { throw new Error("Image response was empty."); }
+            try { data = JSON.parse(text); } catch { throw new Error(`Image request failed (${res.status}): ${text.slice(0, 120)}`); }
             if (!res.ok) throw new Error((data?.error as string) ?? "Failed to generate image.");
             lastError = null;
             if (!cancelled) {
@@ -1878,7 +1878,7 @@ export default function TeacherView({ user }: Props) {
       });
       const text = await res.text();
       let data: Record<string, unknown>;
-      try { data = JSON.parse(text); } catch { throw new Error("Image response was empty."); }
+      try { data = JSON.parse(text); } catch { throw new Error(`Image request failed (${res.status}): ${text.slice(0, 120)}`); }
       if (!res.ok) throw new Error((data?.error as string) ?? "Failed to generate image.");
       setImages((prev) => {
         const current = prev[refineTarget.itemId];


### PR DESCRIPTION
## Fix image generation timeout on Amplify

### Summary

- Image generation and refinement fail in production with `"Image response was empty."` error
- Root cause: `gpt-image-1.5` with `quality: "high"` takes 30–60s, but Amplify Gen 1's API Gateway has a hard ~29s timeout (`maxDuration` only works on Vercel)
- Lambda gets killed mid-response → non-JSON response → frontend `JSON.parse()` fails

### Changes

- Reduce image quality from `"high"` to `"low"` for both `images.generate` and `images.edit` to complete within timeout
- Fix model fallback from `"gpt-image-1.5"` to `"gpt-image-1"`, use `||` instead of `??` to guard against empty strings
- Add `OPENAI_IMAGE_MODEL` to `amplify.yml` so the model can be configured via Amplify Console env vars
- Improve frontend error messages to include HTTP status and response snippet for easier debugging

### Note

Not tested locally due to OpenAI API key permission issue (401: no org access). Please verify image generation and refinement in production after deploy.