### PR TITLE
Add test-student auto-answer flow

### DIFF
--- a/__tests__/api/auto-answer-test-students.test.ts
+++ b/__tests__/api/auto-answer-test-students.test.ts
@@ -1,0 +1,196 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { POST } from "@/app/api/auto-answer-test-students/route";
+
+vi.mock("@/lib/auth", () => ({
+  extractSSOToken: vi.fn(),
+  verifySSOToken: vi.fn(),
+}));
+
+vi.mock("@/lib/quiz-data", () => ({
+  getLesson: vi.fn(),
+}));
+
+vi.mock("@/lib/nosql", () => {
+  let answers: Record<string, Record<string, unknown>> = {};
+
+  return {
+    getQuizStatus: vi.fn(),
+    upsertStudentAnswer: vi.fn(async (input: Record<string, unknown>) => {
+      const key = [
+        input.class_id,
+        input.assignment_id,
+        input.student_id,
+      ].join(":");
+      answers[key] = input;
+      return input;
+    }),
+    __resetStore: () => {
+      answers = {};
+    },
+    __getAnswers: () => Object.values(answers),
+  };
+});
+
+const { extractSSOToken, verifySSOToken } = await import("@/lib/auth");
+const { getLesson } = await import("@/lib/quiz-data");
+const { getQuizStatus, __getAnswers, __resetStore } = await import(
+  "@/lib/nosql"
+) as unknown as {
+  getQuizStatus: ReturnType<typeof vi.fn>;
+  __getAnswers: () => Array<Record<string, unknown>>;
+  __resetStore: () => void;
+};
+
+const lesson = {
+  lesson_number: 1,
+  lesson_title: "Lesson 1",
+  learning_objective: "Test objective",
+  core_ideas: [],
+  misconceptions: {},
+  quiz_items: [
+    {
+      item_id: "L1_Q1",
+      type: "multiple_choice",
+      question_number: 1,
+      stem: "Question 1",
+      options: {
+        A: "Option A",
+        B: "Option B",
+        C: "Option C",
+      },
+      correct_answer: "A",
+    },
+    {
+      item_id: "L1_Q1_confidence",
+      type: "confidence_check",
+      stem: "Confidence",
+      options: {
+        A: "Very confident",
+        B: "Somewhat confident",
+        C: "Not very confident",
+        D: "Just guessing",
+      },
+    },
+  ],
+};
+
+beforeEach(() => {
+  __resetStore();
+  vi.clearAllMocks();
+
+  vi.mocked(extractSSOToken).mockReturnValue("valid-token");
+  vi.mocked(verifySSOToken).mockResolvedValue({
+    userId: "teacher-1",
+    email: "teacher@example.com",
+    name: "Teacher",
+    role: "teacher",
+    classId: "class-1",
+    assignmentId: "assignment-1",
+  });
+  vi.mocked(getQuizStatus).mockImplementation(
+    async (classId: string, assignmentId: string) => ({
+      class_id: classId,
+      assignment_id: assignmentId,
+      lesson_number: 1,
+      status: "published",
+      updated_at: new Date().toISOString(),
+    }),
+  );
+  vi.mocked(getLesson).mockReturnValue(lesson);
+});
+
+describe("POST /api/auto-answer-test-students", () => {
+  it("requires teacher authentication", async () => {
+    vi.mocked(extractSSOToken).mockReturnValue(null);
+
+    const res = await POST(
+      new Request("http://localhost:3000/api/auto-answer-test-students", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ classId: "class-1", assignmentId: "assignment-1" }),
+      }),
+    );
+
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects non-teacher users", async () => {
+    vi.mocked(verifySSOToken).mockResolvedValue({
+      userId: "student-1",
+      email: "student@example.com",
+      name: "Student",
+      role: "student",
+      classId: "class-1",
+      assignmentId: "assignment-1",
+    });
+
+    const res = await POST(
+      new Request("http://localhost:3000/api/auto-answer-test-students", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ classId: "class-1", assignmentId: "assignment-1" }),
+      }),
+    );
+
+    expect(res.status).toBe(403);
+  });
+
+  it("creates answers for all configured test students", async () => {
+    const request = new Request(
+      "http://localhost:3000/api/auto-answer-test-students",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ classId: "class-1", assignmentId: "assignment-1" }),
+      },
+    );
+
+    const firstRes = await POST(request);
+    expect(firstRes.status).toBe(201);
+
+    const firstData = await firstRes.json();
+    expect(firstData.generatedCount).toBe(5);
+    expect(firstData.students).toHaveLength(5);
+
+    const savedAnswers = __getAnswers();
+    expect(savedAnswers).toHaveLength(5);
+    expect(savedAnswers[0]?.answers).toMatchObject({
+      L1_Q1: expect.stringMatching(/^[ABC]$/),
+      L1_Q1_confidence: expect.stringMatching(/^[ABCD]$/),
+    });
+
+    const secondRes = await POST(
+      new Request("http://localhost:3000/api/auto-answer-test-students", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ classId: "class-1", assignmentId: "assignment-1" }),
+      }),
+    );
+    const secondData = await secondRes.json();
+
+    expect(secondData.students[0].answers).toEqual(firstData.students[0].answers);
+    expect(__getAnswers()).toHaveLength(5);
+  });
+
+  it("supports mock teacher mode for local testing", async () => {
+    vi.mocked(extractSSOToken).mockReturnValue(null);
+
+    const res = await POST(
+      new Request("http://localhost:3000/api/auto-answer-test-students", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-engage-mock-user": "teacher",
+        },
+        body: JSON.stringify({ classId: "demo-class", assignmentId: "demo-assignment" }),
+      }),
+    );
+
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.classId).toBe("demo-class");
+    expect(data.assignmentId).toBe("demo-assignment");
+    expect(data.generatedCount).toBe(5);
+  });
+});

--- a/__tests__/lib/student-answer-lookup.test.ts
+++ b/__tests__/lib/student-answer-lookup.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  findExistingStudentAnswer,
+  getCandidateStudentIds,
+} from "@/lib/student-answer-lookup";
+
+describe("getCandidateStudentIds", () => {
+  it("includes the logged-in user id first", () => {
+    expect(getCandidateStudentIds("user-123", "other@example.com")).toEqual([
+      "user-123",
+    ]);
+  });
+
+  it("adds the configured test-student id when the email matches", () => {
+    expect(
+      getCandidateStudentIds("mongo-user-id", "maya@test-student.com"),
+    ).toEqual(["mongo-user-id", "test-student-maya-chen"]);
+  });
+});
+
+describe("findExistingStudentAnswer", () => {
+  it("returns the direct user answer when present", async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          answer: {
+            answers: {
+              L1_Q1: "A",
+            },
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const result = await findExistingStudentAnswer({
+      classId: "class-1",
+      assignmentId: "assignment-1",
+      lessonNumber: 1,
+      userId: "user-123",
+      email: "maya@test-student.com",
+      fetchImpl,
+    });
+
+    expect(result).toEqual({
+      matchedStudentId: "user-123",
+      answer: {
+        answers: {
+          L1_Q1: "A",
+        },
+      },
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the configured test-student id when the direct lookup is empty", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ answer: null }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            answer: {
+              answers: {
+                L1_Q1: "C",
+                L1_Q1_confidence: "B",
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      );
+
+    const result = await findExistingStudentAnswer({
+      classId: "class-1",
+      assignmentId: "assignment-1",
+      lessonNumber: 1,
+      userId: "real-genius-user-id",
+      email: "maya@test-student.com",
+      fetchImpl,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(fetchImpl.mock.calls[0]?.[0]).toContain(
+      "studentId=real-genius-user-id",
+    );
+    expect(fetchImpl.mock.calls[1]?.[0]).toContain(
+      "studentId=test-student-maya-chen",
+    );
+    expect(result).toEqual({
+      matchedStudentId: "test-student-maya-chen",
+      answer: {
+        answers: {
+          L1_Q1: "C",
+          L1_Q1_confidence: "B",
+        },
+      },
+    });
+  });
+});

--- a/app/api/auto-answer-test-students/route.ts
+++ b/app/api/auto-answer-test-students/route.ts
@@ -1,0 +1,195 @@
+import crypto from "node:crypto";
+import { NextResponse } from "next/server";
+
+import { extractSSOToken, verifySSOToken } from "@/lib/auth";
+import { getLesson } from "@/lib/quiz-data";
+import { getQuizStatus, upsertStudentAnswer } from "@/lib/nosql";
+import { TEST_STUDENTS } from "@/lib/test-students";
+import type { QuizItem } from "@/lib/types";
+
+type RequestBody = {
+  classId?: string;
+  assignmentId?: string;
+};
+
+const MOCK_TEACHER_HEADER = "x-engage-mock-user";
+
+const pickDeterministicOption = (
+  item: QuizItem,
+  seed: string,
+) => {
+  const optionKeys = Object.keys(item.options).sort();
+  if (optionKeys.length === 0) {
+    throw new Error(`Quiz item ${item.item_id} has no options.`);
+  }
+
+  const digest = crypto.createHash("sha256").update(seed).digest();
+  const index = digest.readUInt32BE(0) % optionKeys.length;
+  return optionKeys[index];
+};
+
+const buildAnswers = (
+  classId: string,
+  assignmentId: string,
+  lessonNumber: number,
+  studentId: string,
+  studentEmail: string,
+  quizItems: QuizItem[],
+) =>
+  Object.fromEntries(
+    quizItems.map((item) => [
+      item.item_id,
+      pickDeterministicOption(
+        item,
+        `${classId}:${assignmentId}:${lessonNumber}:${studentId}:${studentEmail}:${item.item_id}`,
+      ),
+    ]),
+  );
+
+async function resolveTeacherContext(request: Request, body: RequestBody) {
+  const token = extractSSOToken(request);
+
+  if (token) {
+    const user = await verifySSOToken(token);
+
+    if (user.role !== "teacher") {
+      return {
+        error: NextResponse.json(
+          { error: "Only teachers can auto-answer test students." },
+          { status: 403 },
+        ),
+      };
+    }
+
+    if (!user.classId || !user.assignmentId) {
+      return {
+        error: NextResponse.json(
+          { error: "Teacher SSO context must include classId and assignmentId." },
+          { status: 400 },
+        ),
+      };
+    }
+
+    if (
+      (body.classId && body.classId !== user.classId) ||
+      (body.assignmentId && body.assignmentId !== user.assignmentId)
+    ) {
+      return {
+        error: NextResponse.json(
+          { error: "Body context does not match the current teacher session." },
+          { status: 403 },
+        ),
+      };
+    }
+
+    return {
+      classId: user.classId,
+      assignmentId: user.assignmentId,
+    };
+  }
+
+  if (request.headers.get(MOCK_TEACHER_HEADER) === "teacher") {
+    if (!body.classId || !body.assignmentId) {
+      return {
+        error: NextResponse.json(
+          { error: "classId and assignmentId are required in mock teacher mode." },
+          { status: 400 },
+        ),
+      };
+    }
+
+    return {
+      classId: body.classId,
+      assignmentId: body.assignmentId,
+    };
+  }
+
+  return {
+    error: NextResponse.json(
+      { error: "Teacher authentication is required." },
+      { status: 401 },
+    ),
+  };
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json().catch(() => ({}))) as RequestBody;
+    const context = await resolveTeacherContext(request, body);
+
+    if ("error" in context) {
+      return context.error;
+    }
+
+    const { classId, assignmentId } = context;
+    const quizStatus = await getQuizStatus(classId, assignmentId);
+
+    if (!quizStatus || quizStatus.status !== "published") {
+      return NextResponse.json(
+        { error: "A published quiz is required before generating test submissions." },
+        { status: 409 },
+      );
+    }
+
+    const lesson = getLesson(quizStatus.lesson_number);
+    if (!lesson) {
+      return NextResponse.json(
+        { error: `Lesson ${quizStatus.lesson_number} could not be loaded.` },
+        { status: 404 },
+      );
+    }
+
+    const submittedAt = new Date().toISOString();
+    const students = await Promise.all(
+      TEST_STUDENTS.map(async (student) => {
+        const answers = buildAnswers(
+          classId,
+          assignmentId,
+          lesson.lesson_number,
+          student.id,
+          student.email,
+          lesson.quiz_items,
+        );
+
+        const record = await upsertStudentAnswer({
+          class_id: classId,
+          assignment_id: assignmentId,
+          student_id: student.id,
+          student_name: student.name,
+          lesson_number: lesson.lesson_number,
+          answers,
+          submitted_at: submittedAt,
+        });
+
+        return {
+          studentId: student.id,
+          studentName: student.name,
+          studentEmail: student.email,
+          answers: record.answers,
+          submittedAt: record.submitted_at,
+        };
+      }),
+    );
+
+    return NextResponse.json(
+      {
+        classId,
+        assignmentId,
+        lessonNumber: lesson.lesson_number,
+        generatedCount: students.length,
+        students,
+      },
+      { status: 201 },
+    );
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to auto-answer test students.",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/components/StudentQuizView.tsx
+++ b/app/components/StudentQuizView.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import type { UserContext } from "@/lib/auth";
+import { findExistingStudentAnswer } from "@/lib/student-answer-lookup";
 import type { QuizItem } from "@/lib/types";
 
 type Props = {
@@ -75,14 +76,16 @@ export default function StudentQuizView({ user }: Props) {
       const lessonData = await lessonRes.json();
       setQuestions(lessonData.quiz_items ?? []);
 
-      // Check for existing answers
-      const answerRes = await fetch(
-        `/api/student-answers?classId=${encodeURIComponent(classId)}&assignmentId=${encodeURIComponent(assignmentId)}&studentId=${encodeURIComponent(user.userId)}&lessonNumber=${encodeURIComponent(qs.lesson_number)}`,
-      );
-      const answerData = await answerRes.json();
-      if (answerData.answer) {
-        setExistingAnswers(answerData.answer.answers);
-        setAnswers(answerData.answer.answers);
+      const existingAnswer = await findExistingStudentAnswer({
+        classId,
+        assignmentId,
+        lessonNumber: qs.lesson_number,
+        userId: user.userId,
+        email: user.email,
+      });
+      if (existingAnswer) {
+        setExistingAnswers(existingAnswer.answer.answers);
+        setAnswers(existingAnswer.answer.answers);
         setSubmitted(true);
         notifyQuizSubmitted(classId, assignmentId, user.userId);
       }
@@ -91,7 +94,7 @@ export default function StudentQuizView({ user }: Props) {
     } finally {
       setLoading(false);
     }
-  }, [classId, assignmentId, user.userId]);
+  }, [classId, assignmentId, user.userId, user.email]);
 
   useEffect(() => {
     loadQuiz();

--- a/app/components/TeacherView.tsx
+++ b/app/components/TeacherView.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import type { UserContext } from "@/lib/auth";
+import { MOCK_USER_STORAGE_KEY, parseMockUserRole } from "@/lib/mock-auth";
 import {
   engagementStrategies as strategies,
   getEngagementStrategyDescription,
@@ -22,6 +23,7 @@ import type {
 } from "@/lib/types";
 
 const MAX_IMAGE_VERSIONS = 10;
+const SSO_TOKEN_STORAGE_KEY = "engage-sso-token";
 
 type Props = {
   user: UserContext;
@@ -361,6 +363,7 @@ export default function TeacherView({ user }: Props) {
   // Student answers
   const [studentAnswers, setStudentAnswers] = useState<StudentAnswer[]>([]);
   const [loadingAnswers, setLoadingAnswers] = useState(false);
+  const [autoAnsweringTestStudents, setAutoAnsweringTestStudents] = useState(false);
 
   // Plan
   const [plan, setPlan] = useState<Plan | null>(null);
@@ -531,6 +534,60 @@ export default function TeacherView({ user }: Props) {
       distribution[result.plan.strategy] = (distribution[result.plan.strategy] ?? 0) + 1;
     });
     return distribution;
+  };
+
+  const autoAnswerTestStudents = async () => {
+    if (!classId || !assignmentId) {
+      setError("Missing class or assignment context.");
+      return;
+    }
+
+    setAutoAnsweringTestStudents(true);
+    setError(null);
+
+    try {
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+      };
+
+      if (typeof window !== "undefined") {
+        const token = window.sessionStorage.getItem(SSO_TOKEN_STORAGE_KEY);
+        if (token) {
+          headers.Authorization = `Bearer ${token}`;
+        }
+
+        const mockRole = parseMockUserRole(
+          window.sessionStorage.getItem(MOCK_USER_STORAGE_KEY),
+        );
+        if (mockRole) {
+          headers["x-engage-mock-user"] = mockRole;
+        }
+      }
+
+      const res = await fetch("/api/auto-answer-test-students", {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ classId, assignmentId }),
+      });
+
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(
+          (data as { error?: string }).error ??
+            "Failed to auto-answer test students.",
+        );
+      }
+
+      await loadStudentAnswers();
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Failed to auto-answer test students.",
+      );
+    } finally {
+      setAutoAnsweringTestStudents(false);
+    }
   };
 
   const buildCohortMasterPlan = (
@@ -2080,13 +2137,36 @@ export default function TeacherView({ user }: Props) {
               <div className="rounded-2xl border border-slate-100 bg-slate-50 p-4">
                 <div className="flex items-center justify-between">
                   <p className="text-xs font-semibold uppercase text-slate-400">Student responses</p>
-                  <button type="button" onClick={() => void loadStudentAnswers()} disabled={loadingAnswers}
-                    className="rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-600 transition hover:bg-slate-100">
-                    {loadingAnswers ? "Loading..." : "Refresh"}
-                  </button>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => void autoAnswerTestStudents()}
+                      disabled={
+                        autoAnsweringTestStudents ||
+                        quizStatus !== "published" ||
+                        !hasAssignmentContext
+                      }
+                      className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:text-slate-400"
+                    >
+                      {autoAnsweringTestStudents
+                        ? "Generating..."
+                        : "Auto-answer 5 test students"}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => void loadStudentAnswers()}
+                      disabled={loadingAnswers}
+                      className="rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:text-slate-400"
+                    >
+                      {loadingAnswers ? "Loading..." : "Refresh"}
+                    </button>
+                  </div>
                 </div>
                 <p className="mt-2 text-sm text-slate-700">
                   <span className="font-semibold">{studentAnswers.length}</span> student{studentAnswers.length !== 1 ? "s" : ""} have answered so far.
+                </p>
+                <p className="mt-1 text-xs text-slate-500">
+                  Generates stable random answers for the five configured test students and overwrites their prior submissions for this assignment.
                 </p>
                 {studentAnswers.length > 0 && (
                   <div className="mt-2 flex flex-wrap gap-1">

--- a/lib/student-answer-lookup.ts
+++ b/lib/student-answer-lookup.ts
@@ -1,0 +1,72 @@
+import { findTestStudentByEmail } from "@/lib/test-students";
+
+type ExistingAnswer = {
+  answers: Record<string, string>;
+};
+
+type LookupInput = {
+  classId: string;
+  assignmentId: string;
+  lessonNumber: number;
+  userId: string;
+  email?: string | null;
+  fetchImpl?: typeof fetch;
+};
+
+type LookupResult = {
+  answer: ExistingAnswer;
+  matchedStudentId: string;
+};
+
+const buildAnswerUrl = (
+  classId: string,
+  assignmentId: string,
+  studentId: string,
+  lessonNumber: number,
+) =>
+  `/api/student-answers?classId=${encodeURIComponent(classId)}&assignmentId=${encodeURIComponent(assignmentId)}&studentId=${encodeURIComponent(studentId)}&lessonNumber=${encodeURIComponent(lessonNumber)}`;
+
+export const getCandidateStudentIds = (
+  userId: string,
+  email?: string | null,
+) => {
+  const candidateIds = [userId];
+  const testStudent = findTestStudentByEmail(email);
+
+  if (testStudent && testStudent.id !== userId) {
+    candidateIds.push(testStudent.id);
+  }
+
+  return candidateIds;
+};
+
+export async function findExistingStudentAnswer({
+  classId,
+  assignmentId,
+  lessonNumber,
+  userId,
+  email,
+  fetchImpl = fetch,
+}: LookupInput): Promise<LookupResult | null> {
+  const candidateIds = getCandidateStudentIds(userId, email);
+
+  for (const studentId of candidateIds) {
+    const response = await fetchImpl(
+      buildAnswerUrl(classId, assignmentId, studentId, lessonNumber),
+    );
+    const data = await response.json().catch(() => ({}));
+
+    if (!response.ok) {
+      throw new Error(
+        (data as { error?: string }).error ?? "Failed to load existing answers.",
+      );
+    }
+
+    const answer = (data as { answer?: ExistingAnswer | null }).answer ?? null;
+    if (answer) {
+      return { answer, matchedStudentId: studentId };
+    }
+  }
+
+  return null;
+}

--- a/lib/test-students.ts
+++ b/lib/test-students.ts
@@ -1,0 +1,48 @@
+export type TestStudent = {
+  id: string;
+  name: string;
+  email: string;
+};
+
+export const TEST_STUDENTS: TestStudent[] = [
+  {
+    id: "test-student-maya-chen",
+    name: "Maya Chen",
+    email: "maya@test-student.com",
+  },
+  {
+    id: "test-student-jordan-patel",
+    name: "Jordan Patel",
+    email: "jordan@test-student.com",
+  },
+  {
+    id: "test-student-sofia-ramirez",
+    name: "Sofia Ramirez",
+    email: "sofia@test-student.com",
+  },
+  {
+    id: "test-student-ethan-park",
+    name: "Ethan Park",
+    email: "ethan@test-student.com",
+  },
+  {
+    id: "test-student-amina-hassan",
+    name: "Amina Hassan",
+    email: "amina@test-student.com",
+  },
+];
+
+export const findTestStudentByEmail = (
+  email: string | null | undefined,
+): TestStudent | null => {
+  if (!email) {
+    return null;
+  }
+
+  const normalizedEmail = email.trim().toLowerCase();
+  return (
+    TEST_STUDENTS.find(
+      (student) => student.email.trim().toLowerCase() === normalizedEmail,
+    ) ?? null
+  );
+};


### PR DESCRIPTION
## Summary
- add a teacher-only route to generate stable random quiz answers for the five configured test students
- add a teacher UI action in Step 2 to trigger auto-answer generation and refresh student submissions
- add student-side fallback lookup so logged-in test students see their generated selections as already submitted

## Testing
- npx vitest run __tests__/api/auto-answer-test-students.test.ts __tests__/api/student-answers.test.ts __tests__/lib/student-answer-lookup.test.ts
- npx eslint app/components/StudentQuizView.tsx lib/student-answer-lookup.ts lib/test-students.ts __tests__/lib/student-answer-lookup.test.ts
- npx eslint app/api/auto-answer-test-students/route.ts app/components/TeacherView.tsx lib/test-students.ts __tests__/api/auto-answer-test-students.test.ts