### PR TITLE
Standardize outgoing GENIUS identity as geniusId

### DIFF
--- a/__tests__/api/auth-verify.test.ts
+++ b/__tests__/api/auth-verify.test.ts
@@ -40,6 +40,7 @@ describe("POST /api/auth/verify", () => {
     expect(res.status).toBe(200);
 
     const data = await res.json();
+    expect(data.user.geniusId).toBe("teacher-123");
     expect(data.user.userId).toBe("teacher-123");
     expect(data.user.role).toBe("teacher");
     expect(data.user.classId).toBe("class-abc");

--- a/__tests__/components/student-quiz-view.test.ts
+++ b/__tests__/components/student-quiz-view.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { notifyQuizSubmitted } from "@/app/components/StudentQuizView";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("notifyQuizSubmitted", () => {
+  it("sends the GENIUS identity using geniusId", () => {
+    const postMessage = vi.fn();
+    vi.stubGlobal("window", { parent: { postMessage } });
+
+    notifyQuizSubmitted("class-1", "assignment-1", "genius-user-1");
+
+    expect(postMessage).toHaveBeenCalledWith(
+      {
+        type: "engage-agent.quiz-submitted",
+        classId: "class-1",
+        assignmentId: "assignment-1",
+        geniusId: "genius-user-1",
+      },
+      "*",
+    );
+  });
+});

--- a/__tests__/lib/auth.test.ts
+++ b/__tests__/lib/auth.test.ts
@@ -41,6 +41,7 @@ describe("verifySSOToken", () => {
     });
 
     const user = await verifySSOToken(token);
+    expect(user.geniusId).toBe("teacher-123");
     expect(user.userId).toBe("teacher-123");
     expect(user.email).toBe("teacher@example.com");
     expect(user.name).toBe("Dr. Smith");
@@ -61,6 +62,7 @@ describe("verifySSOToken", () => {
     });
 
     const user = await verifySSOToken(token);
+    expect(user.geniusId).toBe("student-456");
     expect(user.userId).toBe("student-456");
     expect(user.role).toBe("student");
   });

--- a/app/components/StudentQuizView.tsx
+++ b/app/components/StudentQuizView.tsx
@@ -14,7 +14,7 @@ type QuizStatusData = {
   status: "draft" | "published" | "closed";
 };
 
-const notifyQuizSubmitted = (classId: string, assignmentId: string, studentId: string) => {
+export const notifyQuizSubmitted = (classId: string, assignmentId: string, geniusId: string) => {
   if (typeof window === "undefined" || window.parent === window) return;
 
   window.parent.postMessage(
@@ -22,7 +22,7 @@ const notifyQuizSubmitted = (classId: string, assignmentId: string, studentId: s
       type: "engage-agent.quiz-submitted",
       classId,
       assignmentId,
-      studentId,
+      geniusId,
     },
     "*",
   );
@@ -87,14 +87,14 @@ export default function StudentQuizView({ user }: Props) {
         setExistingAnswers(existingAnswer.answer.answers);
         setAnswers(existingAnswer.answer.answers);
         setSubmitted(true);
-        notifyQuizSubmitted(classId, assignmentId, user.userId);
+        notifyQuizSubmitted(classId, assignmentId, user.geniusId);
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load quiz.");
     } finally {
       setLoading(false);
     }
-  }, [classId, assignmentId, user.userId, user.email]);
+  }, [classId, assignmentId, user.geniusId, user.userId, user.email]);
 
   useEffect(() => {
     loadQuiz();
@@ -134,7 +134,7 @@ export default function StudentQuizView({ user }: Props) {
 
       setSubmitted(true);
       setExistingAnswers(answers);
-      notifyQuizSubmitted(classId, assignmentId, user.userId);
+      notifyQuizSubmitted(classId, assignmentId, user.geniusId);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to submit.");
     } finally {

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -5,6 +5,8 @@ export const SSO_ISSUER = "genius-learning-platform";
 export type SSORole = "student" | "teacher" | "guest";
 
 export type UserContext = {
+  geniusId: string;
+  /** @deprecated Use geniusId for cross-application identity. */
   userId: string;
   email: string | null;
   name: string;
@@ -123,6 +125,7 @@ export async function verifySSOToken(token: string): Promise<UserContext> {
   }
 
   return {
+    geniusId: sso.sub,
     userId: sso.sub,
     email: sso.email ?? null,
     name: sso.name ?? "User",

--- a/lib/mock-auth.ts
+++ b/lib/mock-auth.ts
@@ -8,6 +8,7 @@ export const MOCK_USER_STORAGE_KEY = "engage-mock-user-role";
 
 const MOCK_USERS: Record<MockUserRole, UserContext> = {
   teacher: {
+    geniusId: "test-teacher",
     userId: "test-teacher",
     email: "teacher@example.com",
     name: "Test Teacher",
@@ -18,6 +19,7 @@ const MOCK_USERS: Record<MockUserRole, UserContext> = {
     taskId: "demo-teacher-task",
   },
   student: {
+    geniusId: "test-student",
     userId: "test-student",
     email: "student@example.com",
     name: "Test Student",


### PR DESCRIPTION
## Summary
- expose geniusId from verified GENIUS SSO tokens while retaining userId as a compatibility alias
- send geniusId in quiz-submitted messages back to GENIUS
- cover auth and parent-message behavior with tests

## Verification
- npm test (95 tests)
- npm run lint (0 errors; existing warnings only)
- npm run build